### PR TITLE
Add JWT and API key auth with scope policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: CI – Build & Test
 
 on:
   workflow_dispatch:
@@ -6,13 +6,12 @@ on:
     branches: [ "master" ]
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-buildtest-${{ github.ref }}
   cancel-in-progress: true
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: 1
-  # Set to true if you use packages.lock.json across solutions
   USE_LOCKED_MODE: 'false'
 
 jobs:
@@ -56,7 +55,6 @@ jobs:
       - name: Locate coverage file
         id: coverage
         run: |
-          # Find the cobertura coverage file produced by XPlat collector
           FILE=$(find . -type f -name "coverage.cobertura.xml" | head -n1 || true)
           echo "file=${FILE}" >> "$GITHUB_OUTPUT"
 
@@ -70,66 +68,3 @@ jobs:
             **/TestResults/*.trx
             **/TestResults/*/coverage.cobertura.xml
             ${{ steps.coverage.outputs.file }}
-
-  codeql:
-    name: CodeQL (C#)
-    runs-on: ubuntu-latest
-    # CodeQL needs these minimal permissions
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: csharp
-          # Optional: enable additional queries (security-extended or security-and-quality)
-          # queries: security-extended
-
-      - name: Setup .NET 9
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '9.0.x'
-          cache: true
-          cache-dependency-path: |
-            **/*.sln
-            **/*.csproj
-            **/global.json
-            **/nuget.config
-
-      # Let CodeQL detect and build the solution (good default for C#)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Analyze
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:csharp"
-
-  sbom:
-    name: SBOM (SPDX JSON)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          path: "./src"
-          format: spdx-json
-          output-file: ./sbom.spdx.json
-          upload-artifact: false
-
-      - name: Upload SBOM
-        uses: actions/upload-artifact@v4
-        with:
-          name: sbom
-          path: ./sbom.spdx.json
-          if-no-files-found: error

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "0 3 * * 1"  # lunedì alle 03:00 UTC (facoltativo)
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL (C#)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          # queries: security-extended
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+          cache: true
+          cache-dependency-path: |
+            **/*.sln
+            **/*.csproj
+            **/global.json
+            **/nuget.config
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,36 @@
+name: SBOM
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ "CI – Build & Test" ]
+    types: [ "completed" ]
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: SBOM (SPDX JSON)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: "./src"
+          format: spdx-json
+          output-file: ./sbom.spdx.json
+          upload-artifact: false
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: ./sbom.spdx.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 **AegisAPI** is a zero-trust API security gateway built on **.NET 8 + YARP**, with **AI anomaly detection** and **auto-remediation PRs** to keep your APIs safe, fast, and compliant.
 
 [![CI – Build & Test](https://github.com/MatteoRigoni/aegisapi/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/MatteoRigoni/aegisapi/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/actions/workflows/codeql.yml)
+[![SBOM](https://github.com/MatteoRigoni/aegisapi/actions/workflows/sbom.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/actions/workflows/sbom.yml)
 
 ## Quick Start
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,56 +1,56 @@
-\# CI Pipeline
+# CI Pipeline
 
 
 
 [![CI – Build & Test](https://github.com/MatteoRigoni/aegisapi/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/MatteoRigoni/aegisapi/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/security/code-scanning)
-[![SBOM](https://github.com/MatteoRigoni/aegisapi/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/MatteoRigoni/aegisapi/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/actions/workflows/codeql.yml)
+[![SBOM](https://github.com/MatteoRigoni/aegisapi/actions/workflows/sbom.yml/badge.svg?branch=master)](https://github.com/MatteoRigoni/aegisapi/actions/workflows/sbom.yml)
 
 
 
-\## What runs
+## What runs
 
 
 
-\- \*\*Build \& Test (.NET 8)\*\*  
+- **Build & Test (.NET 8)**  
 
 &nbsp; Restores with caching, builds Release with warnings as errors, runs tests, and publishes:
 
-&nbsp; - `test-results/\*.trx`
+&nbsp; - `test-results/*.trx`
 
 &nbsp; - `coverage.cobertura.xml` (XPlat)
 
 
 
-\- \*\*CodeQL (C#)\*\*  
+- **CodeQL (C#)**  
 
-&nbsp; Initializes CodeQL, builds the solution (autobuild), and uploads SARIF to the repository’s \*Code scanning alerts\*.
+&nbsp; Initializes CodeQL, builds the solution (autobuild), and uploads SARIF to the repository’s *Code scanning alerts*.
 
 
 
-\- \*\*SBOM (SPDX JSON)\*\*  
+- **SBOM (SPDX JSON)**  
 
 &nbsp; Generates `sbom.spdx.json` at the repo root and uploads it as an artifact for audit and supply-chain transparency.
 
 
 
-\## Artifacts
+## Artifacts
 
 
 
-\- `test-results` (unit test logs + coverage)
+- `test-results` (unit test logs + coverage)
 
-\- `sbom` (`sbom.spdx.json`)
-
-
-
-\## Tips
+- `sbom` (`sbom.spdx.json`)
 
 
 
-\- Commit `packages.lock.json` and set `USE\_LOCKED\_MODE=true` to enforce deterministic restores.
+## Tips
 
-\- Keep secrets out of CI logs; the pipeline uses least-privilege `permissions` and no custom tokens.
+
+
+- Commit `packages.lock.json` and set `USE_LOCKED_MODE=true` to enforce deterministic restores.
+
+- Keep secrets out of CI logs; the pipeline uses least-privilege `permissions` and no custom tokens.
 
 
 

--- a/src/gateway/Gateway.csproj
+++ b/src/gateway/Gateway.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.8.0" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="9.8.0" />

--- a/src/gateway/Program.cs
+++ b/src/gateway/Program.cs
@@ -1,11 +1,65 @@
 using Gateway.Resilience;
 using Gateway.Settings;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Gateway.Security;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Settings
 builder.Services.Configure<ResilienceSettings>(
     builder.Configuration.GetSection("Resilience"));
+
+// Authentication & Authorization
+const string ApiKeyScheme = "ApiKey";
+var jwtKey = builder.Configuration["Auth:JwtKey"] ?? "dev-secret";
+var apiKeyHash = builder.Configuration["Auth:ApiKeyHash"] ?? string.Empty;
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultScheme = "BearerOrApiKey";
+    options.DefaultChallengeScheme = "BearerOrApiKey";
+})
+.AddPolicyScheme("BearerOrApiKey", JwtBearerDefaults.AuthenticationScheme, options =>
+{
+    options.ForwardDefaultSelector = ctx =>
+    {
+        if (ctx.Request.Headers.ContainsKey("Authorization"))
+            return JwtBearerDefaults.AuthenticationScheme;
+        if (ctx.Request.Headers.ContainsKey("X-API-Key"))
+            return ApiKeyScheme;
+        return JwtBearerDefaults.AuthenticationScheme;
+    };
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = false,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+    };
+})
+.AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(ApiKeyScheme, options =>
+{
+    options.ClaimsIssuer = ApiKeyScheme;
+});
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("ApiReadOrKey", policy =>
+    {
+        policy.RequireAssertion(ctx =>
+            ctx.User.HasClaim("scope", "api.read") ||
+            ctx.User.HasClaim("ApiKey", "Valid"));
+    });
+});
+
+builder.Services.AddSingleton(new ApiKeyValidationOptions(apiKeyHash));
 
 // Resilience v8 per YARP: factory custom che avvolge l'handler
 builder.Services.AddSingleton<Yarp.ReverseProxy.Forwarder.IForwarderHttpClientFactory,
@@ -15,9 +69,6 @@ builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 
 var app = builder.Build();
-
-app.MapGet("/", () => "AegisAPI Gateway up");
-app.MapGet("/healthz", () => Results.Ok());
 
 // security headers (tuoi)
 app.Use(async (ctx, next) =>
@@ -29,6 +80,14 @@ app.Use(async (ctx, next) =>
     ctx.Response.Headers["Content-Security-Policy"] = "default-src 'self'";
     await next();
 });
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/", () => "AegisAPI Gateway up");
+app.MapGet("/healthz", () => Results.Ok());
+app.MapGet("/api/secure", () => Results.Ok("secret"))
+   .RequireAuthorization("ApiReadOrKey");
 
 app.MapReverseProxy();
 app.Run();

--- a/src/gateway/Program.cs
+++ b/src/gateway/Program.cs
@@ -86,8 +86,6 @@ app.UseAuthorization();
 
 app.MapGet("/", () => "AegisAPI Gateway up");
 app.MapGet("/healthz", () => Results.Ok());
-app.MapGet("/api/secure", () => Results.Ok("secret"))
-   .RequireAuthorization("ApiReadOrKey");
 
 app.MapReverseProxy();
 app.Run();

--- a/src/gateway/Security/ApiKeyAuthenticationHandler.cs
+++ b/src/gateway/Security/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+
+namespace Gateway.Security;
+
+public sealed class ApiKeyValidationOptions
+{
+    public string Hash { get; }
+    public ApiKeyValidationOptions(string hash) => Hash = hash;
+}
+
+public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string HeaderName = "X-API-Key";
+    private readonly ApiKeyValidationOptions _options;
+
+    public ApiKeyAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock,
+        ApiKeyValidationOptions validationOptions)
+        : base(options, logger, encoder, clock)
+    {
+        _options = validationOptions;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(HeaderName, out var values))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var provided = values.FirstOrDefault();
+        if (string.IsNullOrEmpty(provided) || string.IsNullOrEmpty(_options.Hash))
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));
+
+        var providedHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(provided)));
+        var providedBytes = Convert.FromHexString(providedHash);
+        var expectedBytes = Convert.FromHexString(_options.Hash);
+
+        if (CryptographicOperations.FixedTimeEquals(providedBytes, expectedBytes))
+        {
+            var claims = new[] { new Claim("ApiKey", "Valid") };
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+
+        return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));
+    }
+}

--- a/src/gateway/appsettings.Development.json
+++ b/src/gateway/appsettings.Development.json
@@ -20,6 +20,6 @@
   },
   "Auth": {
     "JwtKey": "dev-secret",
-    "ApiKeyHash": "7e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
+    "ApiKeyHash": "8e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
   }
 }

--- a/src/gateway/appsettings.Development.json
+++ b/src/gateway/appsettings.Development.json
@@ -17,5 +17,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Auth": {
+    "JwtKey": "dev-secret",
+    "ApiKeyHash": "7e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
   }
 }

--- a/src/gateway/appsettings.json
+++ b/src/gateway/appsettings.json
@@ -41,4 +41,9 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Auth": {
+    "JwtKey": "dev-secret",
+    "ApiKeyHash": "7e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
+  }
 }

--- a/src/gateway/appsettings.json
+++ b/src/gateway/appsettings.json
@@ -14,7 +14,19 @@
   },
   "ReverseProxy": {
     "Routes": {
-      "api": {
+      "secure": {
+        "Order": 0,
+        "ClusterId": "backend",
+        "Match": { "Path": "/api/secure/{**catch-all}" },
+        "AuthorizationPolicy": "ApiReadOrKey",
+        "Transforms": [
+          { "PathRemovePrefix": "/api/secure" }, 
+          { "RequestHeadersCopy": "true" },
+          { "ResponseHeadersCopy": "true" }
+        ]
+      },
+      "public": {
+        "Order": 1,
         "ClusterId": "backend",
         "Match": { "Path": "/api/{**catch-all}" },
         "Transforms": [

--- a/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
+++ b/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
@@ -9,11 +9,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-		<PackageReference Include="coverlet.collector" Version="6.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
+++ b/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
         <PackageReference Include="coverlet.collector" Version="6.0.2" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Gateway.IntegrationTests/PingProxyTests.cs
+++ b/tests/Gateway.IntegrationTests/PingProxyTests.cs
@@ -42,7 +42,7 @@ public class PingProxyTests
                         ["ReverseProxy:Clusters:backend:Destinations:d1:Address"] = backendUrl.EndsWith("/") ? backendUrl : backendUrl + "/",
                         // Explicit configuration
                         ["ReverseProxy:Routes:api:ClusterId"] = "backend",
-                        ["ReverseProxy:Routes:api:Match:Path"] = "/api/{**catch-all}",
+                        ["ReverseProxy:Routes:api:Match:Path"] = "/public/{**catch-all}",
                         ["ReverseProxy:Routes:api:Transforms:0:PathRemovePrefix"] = "/api"
                     });
                 });

--- a/tests/Gateway.IntegrationTests/SecurityTests.cs
+++ b/tests/Gateway.IntegrationTests/SecurityTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Gateway.IntegrationTests;
+
+public class SecurityTests
+{
+    private static string CreateToken(string key, IEnumerable<Claim> claims, DateTime? expires = null)
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+        var creds = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(claims: claims, expires: expires ?? DateTime.UtcNow.AddMinutes(5), signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static string Hash(string value)
+    {
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(string jwtKey, string apiKeyHash)
+    {
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Auth:JwtKey"] = jwtKey,
+                    ["Auth:ApiKeyHash"] = apiKeyHash
+                });
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Secure_With_Valid_Token_Returns_200()
+    {
+        const string jwtKey = "test-secret";
+        var token = CreateToken(jwtKey, new[] { new Claim("scope", "api.read") });
+
+        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", token);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Missing_Scope_Returns_403()
+    {
+        const string jwtKey = "test-secret";
+        var token = CreateToken(jwtKey, Array.Empty<Claim>());
+
+        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", token);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Expired_Token_Returns_401()
+    {
+        const string jwtKey = "test-secret";
+        var token = CreateToken(jwtKey, new[] { new Claim("scope", "api.read") }, DateTime.UtcNow.AddMinutes(-5));
+
+        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", token);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Valid_ApiKey_Returns_200()
+    {
+        var apiKey = "goodkey";
+        using var factory = CreateFactory("test-secret", Hash(apiKey));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Wrong_ApiKey_Returns_401()
+    {
+        using var factory = CreateFactory("test-secret", Hash("expected"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", "wrong");
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_No_Credentials_Returns_401()
+    {
+        using var factory = CreateFactory("test-secret", Hash("expected"));
+        var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+}

--- a/tests/Gateway.IntegrationTests/SecurityTests.cs
+++ b/tests/Gateway.IntegrationTests/SecurityTests.cs
@@ -1,3 +1,7 @@
+// tests/Gateway.IntegrationTests/SecurityTests.cs
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
@@ -11,106 +15,289 @@ namespace Gateway.IntegrationTests;
 
 public class SecurityTests
 {
+    private const string DEV_API_KEY = "8e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e";
+
+    // ===== Helpers =====
+
+    private static async Task<BackendHost> StartBackendAsync(Action<WebApplication> map)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = Array.Empty<string>() });
+        builder.WebHost.UseKestrel().UseUrls("http://127.0.0.1:0");
+
+        var app = builder.Build();
+        map(app); // mappa gli endpoint PRIMA di start
+        await app.StartAsync();
+
+        return new BackendHost(app);
+    }
+
+    private static WebApplicationFactory<Program> CreateGatewayFactory(
+        string backendUrl,
+        IDictionary<string, string?>? extra = null)
+    {
+        if (!backendUrl.EndsWith("/")) backendUrl += "/";
+
+        // Config base: YARP con route secure protetta da "ApiReadOrKey" e route public aperta.
+        var baseConfig = new Dictionary<string, string?>
+        {
+            // ---- YARP routes ----
+            // /api/secure/* -> richiede auth (AuthorizationPolicy = ApiReadOrKey)
+            ["ReverseProxy:Routes:secure:Order"] = "0",
+            ["ReverseProxy:Routes:secure:ClusterId"] = "backend",
+            ["ReverseProxy:Routes:secure:Match:Path"] = "/api/secure/{**catch-all}",
+            ["ReverseProxy:Routes:secure:AuthorizationPolicy"] = "ApiReadOrKey",
+            ["ReverseProxy:Routes:secure:Transforms:0:PathRemovePrefix"] = "/api/secure",
+            ["ReverseProxy:Routes:secure:Transforms:1:RequestHeadersCopy"] = "true",
+            ["ReverseProxy:Routes:secure:Transforms:2:ResponseHeadersCopy"] = "true",
+
+            // /api/* -> pubblico
+            ["ReverseProxy:Routes:public:Order"] = "1",
+            ["ReverseProxy:Routes:public:ClusterId"] = "backend",
+            ["ReverseProxy:Routes:public:Match:Path"] = "/api/{**catch-all}",
+            ["ReverseProxy:Routes:public:Transforms:0:PathRemovePrefix"] = "/api",
+            ["ReverseProxy:Routes:public:Transforms:1:RequestHeadersCopy"] = "true",
+            ["ReverseProxy:Routes:public:Transforms:2:ResponseHeadersCopy"] = "true",
+
+            // ---- Cluster ----
+            ["ReverseProxy:Clusters:backend:LoadBalancingPolicy"] = "PowerOfTwoChoices",
+            ["ReverseProxy:Clusters:backend:Destinations:d1:Address"] = backendUrl,
+            // Alziamo ActivityTimeout per evitare conflitti con test auth
+            ["ReverseProxy:Clusters:backend:HttpRequest:ActivityTimeout"] = "00:00:10",
+
+            // ---- Resilience defaults (se usati) ----
+            ["Resilience:Timeout:DurationSeconds"] = "2",
+            ["Resilience:Retry:Count"] = "2",
+            ["Resilience:Retry:BaseDelayMs"] = "100",
+            ["Resilience:CircuitBreaker:FailureThreshold"] = "5",
+            ["Resilience:CircuitBreaker:BreakDurationSeconds"] = "5",
+
+            // ---- Auth (verranno sovrascritti nei singoli test) ----
+            ["Auth:JwtKey"] = "dev-secret",
+            ["Auth:ApiKeyHash"] = Hash(DEV_API_KEY) // placeholder: ogni test può override
+        };
+
+        if (extra is not null)
+        {
+            foreach (var kv in extra)
+                baseConfig[kv.Key] = kv.Value;
+        }
+
+        return new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(b =>
+            {
+                b.UseEnvironment("Testing");
+                b.ConfigureAppConfiguration((_, cfg) =>
+                {
+                    cfg.AddInMemoryCollection(baseConfig);
+                });
+            });
+    }
+
+    private sealed class BackendHost : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+        public string Url { get; }
+
+        public BackendHost(WebApplication app)
+        {
+            _app = app;
+            Url = _app.Urls.Single();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
     private static string CreateToken(string key, IEnumerable<Claim> claims, DateTime? expires = null)
     {
         var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
         var creds = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
-        var token = new JwtSecurityToken(claims: claims, expires: expires ?? DateTime.UtcNow.AddMinutes(5), signingCredentials: creds);
+        var exp = expires ?? DateTime.UtcNow.AddMinutes(5);
+        var nbf = exp.AddHours(-1);
+        var token = new JwtSecurityToken(
+            claims: claims,
+            notBefore: nbf,
+            expires: exp,
+            signingCredentials: creds);
         return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
     private static string Hash(string value)
-    {
-        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
-    }
+        => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
 
-    private static WebApplicationFactory<Program> CreateFactory(string jwtKey, string apiKeyHash)
+    // ===== Tests =====
+
+    [Fact]
+    public async Task Public_Route_Does_Not_Require_Auth()
     {
-        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        await using var backend = await StartBackendAsync(app =>
         {
-            builder.ConfigureAppConfiguration((_, cfg) =>
-            {
-                cfg.AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["Auth:JwtKey"] = jwtKey,
-                    ["Auth:ApiKeyHash"] = apiKeyHash
-                });
-            });
+            // Ricorda: /api/{**} ha PathRemovePrefix "/api" -> qui diventa "/ping"
+            app.MapGet("/ping", () => Results.Text("pong", "text/plain"));
         });
+
+        using var factory = CreateGatewayFactory(
+            backend.Url,
+            new Dictionary<string, string?>
+            {
+                ["Auth:JwtKey"] = DEV_API_KEY,
+                ["Auth:ApiKeyHash"] = Hash(DEV_API_KEY)
+            });
+
+        var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/ping");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("pong", await resp.Content.ReadAsStringAsync());
     }
 
     [Fact]
     public async Task Secure_With_Valid_Token_Returns_200()
     {
-        const string jwtKey = "test-secret";
-        var token = CreateToken(jwtKey, new[] { new Claim("scope", "api.read") });
+        await using var backend = await StartBackendAsync(app =>
+        {
+            // /api/secure/{**} ha PathRemovePrefix "/api/secure" -> qui "/ping"
+            app.MapGet("/ping", () => Results.Text("pong-secure", "text/plain"));
+        });
 
-        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var token = CreateToken(DEV_API_KEY, new[] { new Claim("scope", "api.read") });
+
+        using var factory = CreateGatewayFactory(
+            backend.Url,
+            new Dictionary<string, string?>
+            {
+                ["Auth:JwtKey"] = DEV_API_KEY,
+                ["Auth:ApiKeyHash"] = Hash(DEV_API_KEY)
+            });
+
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var resp = await client.GetAsync("/api/secure");
+        var resp = await client.GetAsync("/api/secure/ping");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("pong-secure", await resp.Content.ReadAsStringAsync());
     }
 
     [Fact]
     public async Task Secure_With_Missing_Scope_Returns_403()
     {
-        const string jwtKey = "test-secret";
-        var token = CreateToken(jwtKey, Array.Empty<Claim>());
+        await using var backend = await StartBackendAsync(app =>
+        {
+            app.MapGet("/ping", () => Results.Text("pong-secure", "text/plain"));
+        });
 
-        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var token = CreateToken(DEV_API_KEY, Array.Empty<Claim>());
+
+        using var factory = CreateGatewayFactory(
+            backend.Url,
+            new Dictionary<string, string?>
+            {
+                ["Auth:JwtKey"] = DEV_API_KEY,
+                ["Auth:ApiKeyHash"] = Hash("apikey") // non usato in questo test
+            });
+
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var resp = await client.GetAsync("/api/secure");
+        var resp = await client.GetAsync("/api/secure/ping");
         Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
     }
 
     [Fact]
     public async Task Secure_With_Expired_Token_Returns_401()
     {
-        const string jwtKey = "test-secret";
-        var token = CreateToken(jwtKey, new[] { new Claim("scope", "api.read") }, DateTime.UtcNow.AddMinutes(-5));
+        await using var backend = await StartBackendAsync(app =>
+        {
+            app.MapGet("/ping", () => Results.Text("pong-secure", "text/plain"));
+        });
 
-        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var token = CreateToken(DEV_API_KEY, new[] { new Claim("scope", "api.read") }, DateTime.UtcNow.AddMinutes(-10));
+
+        using var factory = CreateGatewayFactory(
+            backend.Url,
+            new Dictionary<string, string?>
+            {
+                ["Auth:JwtKey"] = DEV_API_KEY,
+                ["Auth:ApiKeyHash"] = Hash("apikey") // non usato qui
+            });
+
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new("Bearer", token);
 
-        var resp = await client.GetAsync("/api/secure");
+        var resp = await client.GetAsync("/api/secure/ping");
         Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
     }
 
     [Fact]
     public async Task Secure_With_Valid_ApiKey_Returns_200()
     {
-        var apiKey = "goodkey";
-        using var factory = CreateFactory("test-secret", Hash(apiKey));
-        var client = factory.CreateClient();
-        client.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+        await using var backend = await StartBackendAsync(app =>
+        {
+            app.MapGet("/ping", () => Results.Text("pong-secure", "text/plain"));
+        });
 
-        var resp = await client.GetAsync("/api/secure");
+        using var factory = CreateGatewayFactory(
+            backend.Url,
+            new Dictionary<string, string?>
+            {
+                ["Auth:JwtKey"] = "dev-secret",            // irrilevante per API key
+                ["Auth:ApiKeyHash"] = Hash(DEV_API_KEY)    // hash atteso lato server
+            });
+
+        var client = factory.CreateClient();
+        // L’handler calcola l’hash: serve plaintext qui
+        client.DefaultRequestHeaders.Add("X-API-Key", DEV_API_KEY);
+
+        var resp = await client.GetAsync("/api/secure/ping");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("pong-secure", await resp.Content.ReadAsStringAsync());
     }
 
     [Fact]
     public async Task Secure_With_Wrong_ApiKey_Returns_401()
     {
-        using var factory = CreateFactory("test-secret", Hash("expected"));
+        await using var backend = await StartBackendAsync(app =>
+        {
+            app.MapGet("/ping", () => Results.Text("pong-secure", "text/plain"));
+        });
+
+        using var factory = CreateGatewayFactory(
+            backend.Url,
+            new Dictionary<string, string?>
+            {
+                ["Auth:JwtKey"] = DEV_API_KEY,
+                ["Auth:ApiKeyHash"] = Hash("expected") // atteso != inviato
+            });
+
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add("X-API-Key", "wrong");
 
-        var resp = await client.GetAsync("/api/secure");
+        var resp = await client.GetAsync("/api/secure/ping");
         Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
     }
 
     [Fact]
     public async Task Secure_With_No_Credentials_Returns_401()
     {
-        using var factory = CreateFactory("test-secret", Hash("expected"));
+        await using var backend = await StartBackendAsync(app =>
+        {
+            app.MapGet("/ping", () => Results.Text("pong-secure", "text/plain"));
+        });
+
+        using var factory = CreateGatewayFactory(
+            backend.Url,
+            new Dictionary<string, string?>
+            {
+                ["Auth:JwtKey"] = DEV_API_KEY,
+                ["Auth:ApiKeyHash"] = Hash("expected")
+            });
+
         var client = factory.CreateClient();
 
-        var resp = await client.GetAsync("/api/secure");
+        var resp = await client.GetAsync("/api/secure/ping");
         Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
     }
 }


### PR DESCRIPTION
## Summary
- add JWT bearer authentication with symmetric key
- support X-API-Key header via custom handler
- secure endpoint `/api/secure` requiring `api.read` scope or API key
- include integration tests for token and API key scenarios

## Testing
- ⚠️ `dotnet test` *(dotnet not installed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b05c60108326b831d5de8b89c470