### PR TITLE
Add JWT and API key auth with scope policy

### DIFF
--- a/src/gateway/Program.cs
+++ b/src/gateway/Program.cs
@@ -1,11 +1,65 @@
 using Gateway.Resilience;
 using Gateway.Settings;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Gateway.Security;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Settings
 builder.Services.Configure<ResilienceSettings>(
     builder.Configuration.GetSection("Resilience"));
+
+// Authentication & Authorization
+const string ApiKeyScheme = "ApiKey";
+var jwtKey = builder.Configuration["Auth:JwtKey"] ?? "dev-secret";
+var apiKeyHash = builder.Configuration["Auth:ApiKeyHash"] ?? string.Empty;
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultScheme = "BearerOrApiKey";
+    options.DefaultChallengeScheme = "BearerOrApiKey";
+})
+.AddPolicyScheme("BearerOrApiKey", JwtBearerDefaults.AuthenticationScheme, options =>
+{
+    options.ForwardDefaultSelector = ctx =>
+    {
+        if (ctx.Request.Headers.ContainsKey("Authorization"))
+            return JwtBearerDefaults.AuthenticationScheme;
+        if (ctx.Request.Headers.ContainsKey("X-API-Key"))
+            return ApiKeyScheme;
+        return JwtBearerDefaults.AuthenticationScheme;
+    };
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = false,
+        ValidateAudience = false,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey))
+    };
+})
+.AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(ApiKeyScheme, options =>
+{
+    options.ClaimsIssuer = ApiKeyScheme;
+});
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("ApiReadOrKey", policy =>
+    {
+        policy.RequireAssertion(ctx =>
+            ctx.User.HasClaim("scope", "api.read") ||
+            ctx.User.HasClaim("ApiKey", "Valid"));
+    });
+});
+
+builder.Services.AddSingleton(new ApiKeyValidationOptions(apiKeyHash));
 
 // Resilience v8 per YARP: factory custom che avvolge l'handler
 builder.Services.AddSingleton<Yarp.ReverseProxy.Forwarder.IForwarderHttpClientFactory,
@@ -15,9 +69,6 @@ builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 
 var app = builder.Build();
-
-app.MapGet("/", () => "AegisAPI Gateway up");
-app.MapGet("/healthz", () => Results.Ok());
 
 // security headers (tuoi)
 app.Use(async (ctx, next) =>
@@ -29,6 +80,14 @@ app.Use(async (ctx, next) =>
     ctx.Response.Headers["Content-Security-Policy"] = "default-src 'self'";
     await next();
 });
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/", () => "AegisAPI Gateway up");
+app.MapGet("/healthz", () => Results.Ok());
+app.MapGet("/api/secure", () => Results.Ok("secret"))
+   .RequireAuthorization("ApiReadOrKey");
 
 app.MapReverseProxy();
 app.Run();

--- a/src/gateway/Security/ApiKeyAuthenticationHandler.cs
+++ b/src/gateway/Security/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+
+namespace Gateway.Security;
+
+public sealed class ApiKeyValidationOptions
+{
+    public string Hash { get; }
+    public ApiKeyValidationOptions(string hash) => Hash = hash;
+}
+
+public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string HeaderName = "X-API-Key";
+    private readonly ApiKeyValidationOptions _options;
+
+    public ApiKeyAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock,
+        ApiKeyValidationOptions validationOptions)
+        : base(options, logger, encoder, clock)
+    {
+        _options = validationOptions;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(HeaderName, out var values))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var provided = values.FirstOrDefault();
+        if (string.IsNullOrEmpty(provided) || string.IsNullOrEmpty(_options.Hash))
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));
+
+        var providedHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(provided)));
+        var providedBytes = Convert.FromHexString(providedHash);
+        var expectedBytes = Convert.FromHexString(_options.Hash);
+
+        if (CryptographicOperations.FixedTimeEquals(providedBytes, expectedBytes))
+        {
+            var claims = new[] { new Claim("ApiKey", "Valid") };
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+
+        return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));
+    }
+}

--- a/src/gateway/appsettings.Development.json
+++ b/src/gateway/appsettings.Development.json
@@ -17,5 +17,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Auth": {
+    "JwtKey": "dev-secret",
+    "ApiKeyHash": "7e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
   }
 }

--- a/src/gateway/appsettings.json
+++ b/src/gateway/appsettings.json
@@ -41,4 +41,9 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Auth": {
+    "JwtKey": "dev-secret",
+    "ApiKeyHash": "7e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
+  }
 }

--- a/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
+++ b/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
@@ -9,11 +9,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-		<PackageReference Include="coverlet.collector" Version="6.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Gateway.IntegrationTests/SecurityTests.cs
+++ b/tests/Gateway.IntegrationTests/SecurityTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Gateway.IntegrationTests;
+
+public class SecurityTests
+{
+    private static string CreateToken(string key, IEnumerable<Claim> claims, DateTime? expires = null)
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+        var creds = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(claims: claims, expires: expires ?? DateTime.UtcNow.AddMinutes(5), signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static string Hash(string value)
+    {
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(string jwtKey, string apiKeyHash)
+    {
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Auth:JwtKey"] = jwtKey,
+                    ["Auth:ApiKeyHash"] = apiKeyHash
+                });
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Secure_With_Valid_Token_Returns_200()
+    {
+        const string jwtKey = "test-secret";
+        var token = CreateToken(jwtKey, new[] { new Claim("scope", "api.read") });
+
+        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", token);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Missing_Scope_Returns_403()
+    {
+        const string jwtKey = "test-secret";
+        var token = CreateToken(jwtKey, Array.Empty<Claim>());
+
+        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", token);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Expired_Token_Returns_401()
+    {
+        const string jwtKey = "test-secret";
+        var token = CreateToken(jwtKey, new[] { new Claim("scope", "api.read") }, DateTime.UtcNow.AddMinutes(-5));
+
+        using var factory = CreateFactory(jwtKey, Hash("apikey"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", token);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Valid_ApiKey_Returns_200()
+    {
+        var apiKey = "goodkey";
+        using var factory = CreateFactory("test-secret", Hash(apiKey));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", apiKey);
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_Wrong_ApiKey_Returns_401()
+    {
+        using var factory = CreateFactory("test-secret", Hash("expected"));
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-API-Key", "wrong");
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Secure_With_No_Credentials_Returns_401()
+    {
+        using var factory = CreateFactory("test-secret", Hash("expected"));
+        var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/api/secure");
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- add JWT bearer authentication with symmetric key
- support X-API-Key header via custom handler
- secure endpoint `/api/secure` requiring `api.read` scope or API key
- include integration tests for token and API key scenarios

## Testing
- ⚠️ `dotnet test` *(dotnet not installed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b05c60108326b831d5de8b89c470