### PR TITLE
docs: document authentication options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,19 @@ cd src/gateway
 dotnet run
 
 # Test endpoints
-curl http://localhost:5000/              # Returns "AegisAPI Gateway up"
-curl http://localhost:5000/healthz       # Returns 200 OK
-curl http://localhost:5000/api/ping      # Proxies to backend /ping endpoint
+curl http://localhost:5000/                             # Returns "AegisAPI Gateway up"
+curl http://localhost:5000/healthz                      # Returns 200 OK
+curl http://localhost:5000/api/ping                     # Public route
+curl -H "Authorization: Bearer <token>" http://localhost:5000/api/secure/ping  # Protected route (JWT)
+curl -H "X-API-Key: <key>" http://localhost:5000/api/secure/ping               # Protected route (API key)
 ```
+
+## Autenticazione
+
+AegisAPI supporta due modalità di autenticazione:
+
+- **JWT**: inviare un token nell'intestazione `Authorization: Bearer <token>`. Per lo sviluppo, impostare il segreto simmetrico tramite `Auth:JwtKey` in `src/gateway/appsettings.Development.json`.
+- **API key**: inviare la chiave nell'intestazione `X-API-Key: <chiave>`. Per lo sviluppo, configurare `Auth:ApiKeyHash` nello stesso file con l'hash SHA-256 della chiave (`echo -n tua-chiave | sha256sum`).
 
 ### ✨ Features
 


### PR DESCRIPTION
## Summary
- clarify curl examples for public and secure routes
- describe JWT and API-key authentication and dev configuration

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e660a6548326bcb8b3367c5cc9b6