### PR TITLE
refactor: remove obsolete system clock usage

### DIFF
--- a/src/gateway/Security/ApiKeyAuthenticationHandler.cs
+++ b/src/gateway/Security/ApiKeyAuthenticationHandler.cs
@@ -21,9 +21,8 @@ public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<Authenti
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
         UrlEncoder encoder,
-        ISystemClock clock,
         IOptionsMonitor<ApiKeyValidationOptions> validationOptions)
-        : base(options, logger, encoder, clock)
+        : base(options, logger, encoder)
     {
         _options = validationOptions;
     }


### PR DESCRIPTION
## Summary
- replace obsolete `ISystemClock` dependency with modern constructor using `TimeProvider` defaults

## Testing
- `dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `dotnet test --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e8971c788326854fcb0e6f336f1f