### PR TITLE
Implement per-client token bucket rate limiter

### DIFF
--- a/src/gateway/Program.cs
+++ b/src/gateway/Program.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Gateway.Resilience;
 using Gateway.Security;
 using Gateway.Settings;
+using Gateway.RateLimiting;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -10,6 +11,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Resilience configuration
 builder.Services.Configure<ResilienceSettings>(builder.Configuration.GetSection("Resilience"));
+builder.Services.Configure<RateLimitingSettings>(builder.Configuration.GetSection("RateLimiting"));
+builder.Services.AddMemoryCache();
 
 const string ApiKeyScheme = "ApiKey";
 const string BearerOrApiKeyScheme = "BearerOrApiKey";
@@ -82,6 +85,7 @@ app.Use(async (ctx, next) =>
 });
 
 app.UseAuthentication();
+app.UseMiddleware<ClientRateLimiterMiddleware>();
 app.UseAuthorization();
 
 app.MapGet("/", () => "AegisAPI Gateway up");

--- a/src/gateway/RateLimiting/ClientRateLimiterMiddleware.cs
+++ b/src/gateway/RateLimiting/ClientRateLimiterMiddleware.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Linq;
+using Gateway.Security;
+using Gateway.Settings;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Gateway.RateLimiting;
+
+public sealed class ClientRateLimiterMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IMemoryCache _cache;
+    private readonly RateLimitingSettings _settings;
+
+    public ClientRateLimiterMiddleware(
+        RequestDelegate next,
+        IMemoryCache cache,
+        IOptions<RateLimitingSettings> options)
+    {
+        _next = next;
+        _cache = cache;
+        _settings = options.Value;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var clientId = GetClientId(context);
+        if (clientId is null)
+        {
+            await _next(context);
+            return;
+        }
+
+        var plan = context.User.FindFirst("plan")?.Value;
+        var limit = _settings.GetLimit(plan);
+        var now = DateTime.UtcNow;
+
+        var bucket = _cache.GetOrCreate(clientId, e =>
+        {
+            e.SlidingExpiration = TimeSpan.FromMinutes(5);
+            return new TokenBucket(limit, now);
+        });
+        double retryAfter;
+        var allowed = false;
+        lock (bucket!)
+        {
+            allowed = bucket!.TryConsume(limit, now, out retryAfter);
+        }
+
+        if (!allowed)
+        {
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            context.Response.Headers["Retry-After"] = Math.Ceiling(retryAfter).ToString(CultureInfo.InvariantCulture);
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private static string? GetClientId(HttpContext context)
+    {
+        var sub = context.User.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub))
+            return sub;
+
+        if (context.Request.Headers.TryGetValue(ApiKeyAuthenticationHandler.HeaderName, out var apiKeyValues))
+        {
+            var apiKey = apiKeyValues.FirstOrDefault();
+            if (!string.IsNullOrEmpty(apiKey))
+            {
+                var hash = SHA256.HashData(Encoding.UTF8.GetBytes(apiKey));
+                return Convert.ToHexString(hash);
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class TokenBucket
+    {
+        private double _tokens;
+        private DateTime _lastRefill;
+
+        public TokenBucket(int capacity, DateTime now)
+        {
+            _tokens = capacity;
+            _lastRefill = now;
+        }
+
+        public bool TryConsume(int capacity, DateTime now, out double retryAfter)
+        {
+            var ratePerSec = capacity / 60d;
+            var delta = (now - _lastRefill).TotalSeconds * ratePerSec;
+            _tokens = Math.Min(capacity, _tokens + delta);
+            _lastRefill = now;
+
+            if (_tokens >= 1)
+            {
+                _tokens -= 1;
+                retryAfter = 0;
+                return true;
+            }
+
+            retryAfter = (1 - _tokens) / ratePerSec;
+            return false;
+        }
+    }
+}

--- a/src/gateway/Settings/RateLimitingSettings.cs
+++ b/src/gateway/Settings/RateLimitingSettings.cs
@@ -1,0 +1,14 @@
+namespace Gateway.Settings;
+
+public class RateLimitingSettings
+{
+    public int DefaultRpm { get; set; } = 100;
+    public Dictionary<string, int> Plans { get; set; } = new();
+
+    public int GetLimit(string? plan)
+    {
+        if (!string.IsNullOrEmpty(plan) && Plans.TryGetValue(plan, out var limit))
+            return limit;
+        return DefaultRpm;
+    }
+}

--- a/src/gateway/appsettings.Development.json
+++ b/src/gateway/appsettings.Development.json
@@ -21,5 +21,11 @@
   "Auth": {
     "JwtKey": "dev-secret",
     "ApiKeyHash": "8e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
+  },
+  "RateLimiting": {
+    "DefaultRpm": 100,
+    "Plans": {
+      "gold": 1000
+    }
   }
 }

--- a/src/gateway/appsettings.json
+++ b/src/gateway/appsettings.json
@@ -57,5 +57,11 @@
   "Auth": {
     "JwtKey": "dev-secret",
     "ApiKeyHash": "7e9f8fd111802be56c379d597842e29b2cebd35ff2133d431a49fa556a18704e"
+  },
+  "RateLimiting": {
+    "DefaultRpm": 100,
+    "Plans": {
+      "gold": 1000
+    }
   }
 }

--- a/tests/Gateway.IntegrationTests/RateLimitingTests.cs
+++ b/tests/Gateway.IntegrationTests/RateLimitingTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Gateway.IntegrationTests;
+
+public class RateLimitingTests
+{
+    private const string JwtKey = "dev-secret";
+
+    private static string CreateToken(string sub, string? plan = null)
+    {
+        var claims = new List<Claim> { new("sub", sub) };
+        if (plan is not null)
+            claims.Add(new("plan", plan));
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtKey));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(claims: claims, expires: DateTime.UtcNow.AddMinutes(5), signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory()
+        => new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.UseEnvironment("Testing");
+                builder.ConfigureAppConfiguration((_, cfg) =>
+                {
+                    cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["RateLimiting:DefaultRpm"] = "2",
+                        ["RateLimiting:Plans:gold"] = "4"
+                    });
+                });
+            });
+
+    [Fact]
+    public async Task Exceeding_Limit_Returns_429()
+    {
+        using var factory = CreateFactory();
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", CreateToken("user1"));
+
+        var r1 = await client.GetAsync("/");
+        var r2 = await client.GetAsync("/");
+        var r3 = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, r1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, r2.StatusCode);
+        Assert.Equal(HttpStatusCode.TooManyRequests, r3.StatusCode);
+        Assert.True(r3.Headers.TryGetValues("Retry-After", out _));
+    }
+
+    [Fact]
+    public async Task Separate_Clients_Do_Not_Throttle_Each_Other()
+    {
+        using var factory = CreateFactory();
+        var client = factory.CreateClient();
+
+        client.DefaultRequestHeaders.Authorization = new("Bearer", CreateToken("clientA"));
+        await client.GetAsync("/");
+        await client.GetAsync("/");
+        var blocked = await client.GetAsync("/");
+
+        client.DefaultRequestHeaders.Authorization = new("Bearer", CreateToken("clientB"));
+        var allowed = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, blocked.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
+    }
+
+    [Fact]
+    public async Task Gold_Plan_Has_Higher_Limit()
+    {
+        using var factory = CreateFactory();
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new("Bearer", CreateToken("goldUser", "gold"));
+
+        var statuses = new List<HttpStatusCode>();
+        for (var i = 0; i < 5; i++)
+        {
+            var resp = await client.GetAsync("/");
+            statuses.Add(resp.StatusCode);
+        }
+
+        Assert.True(statuses.Take(4).All(s => s == HttpStatusCode.OK));
+        Assert.Equal(HttpStatusCode.TooManyRequests, statuses.Last());
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable rate limiting settings and middleware deriving client IDs from JWT `sub` or API key
- wire middleware in gateway pipeline and default config with 100 rpm or 1000 rpm for gold plan
- add integration tests for rate limiting behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ebe5d69c8326bc0faa0cd7003fdf