### PR TITLE
Add request feature queue and consumer stub

### DIFF
--- a/src/gateway/Features/FeatureCollectorMiddleware.cs
+++ b/src/gateway/Features/FeatureCollectorMiddleware.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Http;
+using System.Linq;
+
+namespace Gateway.Features;
+
+public class FeatureCollectorMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IRequestFeatureQueue _queue;
+
+    public FeatureCollectorMiddleware(RequestDelegate next, IRequestFeatureQueue queue)
+    {
+        _next = next;
+        _queue = queue;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        await _next(context);
+
+        var clientId = context.Items.TryGetValue("ClientId", out var cId) ? cId as string : null;
+        var rpsWindow = context.Items.TryGetValue("RpsWindow", out var rps) ? Convert.ToDouble(rps) : 0d;
+        var ua = context.Request.Headers.UserAgent.ToString();
+        var uaEntropy = CalculateEntropy(ua);
+        var path = context.Request.Path.ToString();
+        var status = context.Response.StatusCode;
+        var schemaError = context.Items.ContainsKey("SchemaError");
+
+        var feature = new RequestFeature(clientId, rpsWindow, uaEntropy, path, status, schemaError);
+        _queue.Enqueue(feature);
+    }
+
+    private static double CalculateEntropy(string input)
+    {
+        if (string.IsNullOrEmpty(input)) return 0;
+        var groups = input.GroupBy(c => c);
+        var entropy = 0d;
+        foreach (var g in groups)
+        {
+            var p = (double)g.Count() / input.Length;
+            entropy -= p * Math.Log2(p);
+        }
+        return entropy;
+    }
+}

--- a/src/gateway/Features/FeatureConsumer.cs
+++ b/src/gateway/Features/FeatureConsumer.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+
+namespace Gateway.Features;
+
+public class FeatureConsumer : BackgroundService
+{
+    private readonly IRequestFeatureQueue _queue;
+    public ConcurrentBag<RequestFeature> Features { get; } = new();
+
+    public FeatureConsumer(IRequestFeatureQueue queue)
+    {
+        _queue = queue;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var feature in _queue.DequeueAllAsync(stoppingToken))
+        {
+            Features.Add(feature);
+        }
+    }
+}

--- a/src/gateway/Features/RequestFeature.cs
+++ b/src/gateway/Features/RequestFeature.cs
@@ -1,0 +1,9 @@
+namespace Gateway.Features;
+
+public record RequestFeature(
+    string? ClientId,
+    double RpsWindow,
+    double UaEntropy,
+    string Path,
+    int Status,
+    bool SchemaError);

--- a/src/gateway/Features/RequestFeatureQueue.cs
+++ b/src/gateway/Features/RequestFeatureQueue.cs
@@ -1,0 +1,30 @@
+using System.Threading.Channels;
+
+namespace Gateway.Features;
+
+public interface IRequestFeatureQueue
+{
+    void Enqueue(RequestFeature feature);
+    IAsyncEnumerable<RequestFeature> DequeueAllAsync(CancellationToken token);
+    void Seed(IEnumerable<RequestFeature> features);
+}
+
+public class RequestFeatureQueue : IRequestFeatureQueue
+{
+    private readonly Channel<RequestFeature> _channel = Channel.CreateUnbounded<RequestFeature>();
+
+    public void Enqueue(RequestFeature feature)
+    {
+        _channel.Writer.TryWrite(feature);
+    }
+
+    public IAsyncEnumerable<RequestFeature> DequeueAllAsync(CancellationToken token) => _channel.Reader.ReadAllAsync(token);
+
+    public void Seed(IEnumerable<RequestFeature> features)
+    {
+        foreach (var feature in features)
+        {
+            _channel.Writer.TryWrite(feature);
+        }
+    }
+}

--- a/src/gateway/RateLimiting/ClientRateLimiterMiddleware.cs
+++ b/src/gateway/RateLimiting/ClientRateLimiterMiddleware.cs
@@ -38,6 +38,8 @@ public sealed class ClientRateLimiterMiddleware
 
         var plan = context.User.FindFirst("plan")?.Value;
         var limit = _settings.GetLimit(plan);
+        context.Items["ClientId"] = clientId;
+        context.Items["RpsWindow"] = limit / 60d;
         var now = DateTime.UtcNow;
 
         var bucket = _cache.GetOrCreate(clientId, e =>

--- a/src/gateway/Validation/JsonValidationMiddleware.cs
+++ b/src/gateway/Validation/JsonValidationMiddleware.cs
@@ -42,6 +42,7 @@ public class JsonValidationMiddleware
                 if (!result.IsValid)
                 {
                     GatewayDiagnostics.SchemaValidationErrors.Add(1);
+                    context.Items["SchemaError"] = true;
                     context.Response.StatusCode = StatusCodes.Status400BadRequest;
                     var errors = result.Details
                        .Where(d => d.Errors != null && d.Errors.Count > 0)
@@ -62,6 +63,7 @@ public class JsonValidationMiddleware
                 if (!result.IsValid)
                 {
                     GatewayDiagnostics.SchemaValidationErrors.Add(1);
+                    context.Items["SchemaError"] = true;
                     context.Response.StatusCode = StatusCodes.Status400BadRequest;
                     var errors = result.Details
                        .Where(d => d.Errors != null && d.Errors.Count > 0)
@@ -90,6 +92,7 @@ public class JsonValidationMiddleware
                 if (!result.IsValid)
                 {
                     GatewayDiagnostics.SchemaValidationErrors.Add(1);
+                    context.Items["SchemaError"] = true;
                     context.Response.Body = originalBody;
                     context.Response.StatusCode = StatusCodes.Status500InternalServerError;
                     var errors = result.Details

--- a/tests/Gateway.IntegrationTests/FeatureTests.cs
+++ b/tests/Gateway.IntegrationTests/FeatureTests.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Json;
+using Gateway.Features;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Gateway.IntegrationTests;
+
+public class FeatureTests
+{
+    private static async Task WaitForFeaturesAsync(FeatureConsumer consumer, int count)
+    {
+        var sw = Stopwatch.StartNew();
+        while (consumer.Features.Count < count && sw.ElapsedMilliseconds < 1000)
+        {
+            await Task.Delay(10);
+        }
+    }
+
+    [Fact]
+    public async Task ProducesFeatureForSuccessfulRequest()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("test-agent");
+
+        var response = await client.GetAsync("/");
+        response.EnsureSuccessStatusCode();
+
+        var consumer = factory.Services.GetRequiredService<FeatureConsumer>();
+        await WaitForFeaturesAsync(consumer, 1);
+
+        var feature = Assert.Single(consumer.Features);
+        Assert.Equal("/", feature.Path);
+        Assert.Equal(200, feature.Status);
+        Assert.False(feature.SchemaError);
+    }
+
+    [Fact]
+    public async Task ProducesFeatureForSchemaError()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("test-agent");
+
+        var response = await client.PostAsJsonAsync("/api/echo", new { });
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var consumer = factory.Services.GetRequiredService<FeatureConsumer>();
+        await WaitForFeaturesAsync(consumer, 1);
+
+        var feature = Assert.Single(consumer.Features);
+        Assert.Equal("/api/echo", feature.Path);
+        Assert.Equal(400, feature.Status);
+        Assert.True(feature.SchemaError);
+    }
+
+    [Fact]
+    public async Task CanSeedFakeData()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        var queue = factory.Services.GetRequiredService<IRequestFeatureQueue>();
+        queue.Seed(new[] { new RequestFeature("seed-client", 1, 0.5, "/seed", 200, false) });
+
+        var consumer = factory.Services.GetRequiredService<FeatureConsumer>();
+        await WaitForFeaturesAsync(consumer, 1);
+
+        var feature = Assert.Single(consumer.Features);
+        Assert.Equal("seed-client", feature.ClientId);
+    }
+}


### PR DESCRIPTION
## Summary
- capture request features (client id, RPS window, UA entropy, path, status, schema errors)
- enqueue features via in-memory channel and consume in background
- expose seeding of features and add integration tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a332a696f08326b07fb19a571b4171