### PR TITLE
feat: add rolling anomaly detection with ML.NET option

### DIFF
--- a/src/gateway/Features/AnomalyDetectionSettings.cs
+++ b/src/gateway/Features/AnomalyDetectionSettings.cs
@@ -1,0 +1,12 @@
+namespace Gateway.Features;
+
+public class AnomalyDetectionSettings
+{
+    public int WindowSeconds { get; set; } = 1; // size of rolling window
+    public double RpsThreshold { get; set; } = 100;
+    public int FourXxThreshold { get; set; } = 20;
+    public int FiveXxThreshold { get; set; } = 5;
+    public int WafThreshold { get; set; } = 0;
+    public bool UseMl { get; set; } = false;
+    public bool UseIsolationForest { get; set; } = false;
+}

--- a/src/gateway/Features/AnomalyDetector.cs
+++ b/src/gateway/Features/AnomalyDetector.cs
@@ -1,0 +1,123 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+using System.Collections.Concurrent;
+
+namespace Gateway.Features;
+
+public class AnomalyDetector : BackgroundService
+{
+    private readonly IRequestFeatureQueue _queue;
+    private readonly AnomalyDetectionSettings _settings;
+    private readonly ConcurrentDictionary<(string client, string path), SlidingWindow> _windows = new();
+    private readonly MLContext? _mlContext;
+    private readonly ITransformer? _mlModel;
+    private readonly PredictionEngine<AnomalyVector, AnomalyPrediction>? _predictionEngine;
+
+    public ConcurrentBag<RequestFeature> Anomalies { get; } = new();
+
+    public AnomalyDetector(IRequestFeatureQueue queue, IOptions<AnomalyDetectionSettings> options)
+    {
+        _queue = queue;
+        _settings = options.Value;
+
+        if (_settings.UseMl)
+        {
+            _mlContext = new MLContext();
+            var data = new List<AnomalyVector>
+            {
+                new() { Features = new float[] {0,0,0,0} }
+            };
+            var train = _mlContext.Data.LoadFromEnumerable(data);
+            var estimator = _settings.UseIsolationForest
+                ? _mlContext.AnomalyDetection.Trainers.IsolationForest(nameof(AnomalyVector.Features))
+                : _mlContext.AnomalyDetection.Trainers.RandomizedPca(nameof(AnomalyVector.Features));
+            _mlModel = estimator.Fit(train);
+            _predictionEngine = _mlContext.Model.CreatePredictionEngine<AnomalyVector, AnomalyPrediction>(_mlModel);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var feature in _queue.DequeueAllAsync(stoppingToken))
+        {
+            if (IsAnomaly(feature))
+                Anomalies.Add(feature);
+        }
+    }
+
+    private bool IsAnomaly(RequestFeature feature)
+    {
+        var now = DateTime.UtcNow;
+        var key = (feature.ClientId ?? "unknown", feature.Path);
+        var window = _windows.GetOrAdd(key, _ => new SlidingWindow(TimeSpan.FromSeconds(_settings.WindowSeconds)));
+        window.Add(feature, now);
+
+        var rps = window.Rps;
+        var four = window.FourXx;
+        var five = window.FiveXx;
+        var waf = window.WafHits;
+
+        if (rps > _settings.RpsThreshold || four > _settings.FourXxThreshold ||
+            five > _settings.FiveXxThreshold || waf > _settings.WafThreshold)
+            return true;
+
+        if (_settings.UseMl && _predictionEngine is not null)
+        {
+            var vector = new AnomalyVector { Features = new float[] { (float)rps, four, five, waf } };
+            var prediction = _predictionEngine.Predict(vector);
+            return prediction.Prediction[0] == 1;
+        }
+
+        return false;
+    }
+
+    private sealed class SlidingWindow
+    {
+        private readonly TimeSpan _window;
+        private readonly Queue<(DateTime ts, int status, bool waf)> _events = new();
+        private int _four;
+        private int _five;
+        private int _waf;
+
+        public SlidingWindow(TimeSpan window) => _window = window;
+
+        public void Add(RequestFeature feature, DateTime now)
+        {
+            _events.Enqueue((now, feature.Status, feature.WafHit));
+            if (feature.Status is >=400 and <500) _four++;
+            if (feature.Status >=500) _five++;
+            if (feature.WafHit) _waf++;
+            Cleanup(now);
+        }
+
+        private void Cleanup(DateTime now)
+        {
+            while (_events.Count > 0 && now - _events.Peek().ts > _window)
+            {
+                var old = _events.Dequeue();
+                if (old.status is >=400 and <500) _four--;
+                if (old.status >=500) _five--;
+                if (old.waf) _waf--;
+            }
+        }
+
+        public double Rps => _events.Count / _window.TotalSeconds;
+        public int FourXx => _four;
+        public int FiveXx => _five;
+        public int WafHits => _waf;
+    }
+
+    private class AnomalyVector
+    {
+        [VectorType(4)]
+        public float[] Features { get; set; } = Array.Empty<float>();
+    }
+
+    private class AnomalyPrediction
+    {
+        [VectorType(1)]
+        public float[] Prediction { get; set; } = Array.Empty<float>();
+    }
+}

--- a/src/gateway/Features/FeatureCollectorMiddleware.cs
+++ b/src/gateway/Features/FeatureCollectorMiddleware.cs
@@ -25,8 +25,9 @@ public class FeatureCollectorMiddleware
         var path = context.Request.Path.ToString();
         var status = context.Response.StatusCode;
         var schemaError = context.Items.ContainsKey("SchemaError");
+        var wafHit = context.Items.ContainsKey("WafHit");
 
-        var feature = new RequestFeature(clientId, rpsWindow, uaEntropy, path, status, schemaError);
+        var feature = new RequestFeature(clientId, rpsWindow, uaEntropy, path, status, schemaError, wafHit);
         _queue.Enqueue(feature);
     }
 

--- a/src/gateway/Features/RequestFeature.cs
+++ b/src/gateway/Features/RequestFeature.cs
@@ -6,4 +6,5 @@ public record RequestFeature(
     double UaEntropy,
     string Path,
     int Status,
-    bool SchemaError);
+    bool SchemaError,
+    bool WafHit = false);

--- a/src/gateway/Gateway.csproj
+++ b/src/gateway/Gateway.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="Microsoft.ML" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/gateway/Program.cs
+++ b/src/gateway/Program.cs
@@ -84,6 +84,9 @@ builder.Services.AddReverseProxy().LoadFromConfig(builder.Configuration.GetSecti
 builder.Services.AddSingleton<IRequestFeatureQueue, RequestFeatureQueue>();
 builder.Services.AddSingleton<FeatureConsumer>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<FeatureConsumer>());
+builder.Services.Configure<AnomalyDetectionSettings>(builder.Configuration.GetSection("AnomalyDetection"));
+builder.Services.AddSingleton<AnomalyDetector>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<AnomalyDetector>());
 
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(rb => rb.AddService("gateway"))

--- a/src/gateway/Security/WafMiddleware.cs
+++ b/src/gateway/Security/WafMiddleware.cs
@@ -26,6 +26,7 @@ public sealed class WafMiddleware
         {
             _logger.LogWarning("Request blocked by WAF: {Reason}", reason);
             GatewayDiagnostics.WafBlocks.Add(1);
+            context.Items["WafHit"] = true;
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsync("Forbidden");
             return;

--- a/tests/Gateway.IntegrationTests/AnomalyDetectorTests.cs
+++ b/tests/Gateway.IntegrationTests/AnomalyDetectorTests.cs
@@ -1,0 +1,46 @@
+using Gateway.Features;
+using Microsoft.Extensions.Options;
+
+namespace Gateway.IntegrationTests;
+
+public class AnomalyDetectorTests
+{
+    [Fact]
+    public async Task DetectsExpectedAnomalies()
+    {
+        var queue = new RequestFeatureQueue();
+        var settings = Options.Create(new AnomalyDetectionSettings
+        {
+            WindowSeconds = 1,
+            RpsThreshold = 3,
+            FourXxThreshold = 1,
+            FiveXxThreshold = 0,
+            WafThreshold = 0,
+            UseMl = false
+        });
+        var detector = new AnomalyDetector(queue, settings);
+        await detector.StartAsync(CancellationToken.None);
+
+        // Normal traffic
+        queue.Enqueue(new RequestFeature("c1", 0, 0, "/r", 200, false));
+        queue.Enqueue(new RequestFeature("c1", 0, 0, "/r", 200, false));
+        queue.Enqueue(new RequestFeature("c1", 0, 0, "/r", 404, false));
+        queue.Enqueue(new RequestFeature("c1", 0, 0, "/r", 404, false)); // triggers 4xx and rps
+
+        await Task.Delay(1100); // allow window to reset
+        queue.Enqueue(new RequestFeature("c1", 0, 0, "/r", 500, false)); // triggers 5xx
+
+        await Task.Delay(1100);
+        queue.Enqueue(new RequestFeature("c1", 0, 0, "/r", 200, false, true)); // triggers WAF
+
+        var sw = new System.Diagnostics.Stopwatch();
+        sw.Start();
+        while (detector.Anomalies.Count < 3 && sw.ElapsedMilliseconds < 5000)
+        {
+            await Task.Delay(50);
+        }
+
+        Assert.Equal(3, detector.Anomalies.Count);
+        await detector.StopAsync(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary
- queue features include WAF hit flag
- add anomaly detector with rolling thresholds and optional ML.NET isolation forest
- integrate detector into startup and add labelled test sequence

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57d2a489c832695417c4bd5fe1a5d