### PR TITLE
Fix anomaly detection PCA rank and stabilize integration tests

### DIFF
--- a/tests/Gateway.IntegrationTests/AnomalyDetectionTests.cs
+++ b/tests/Gateway.IntegrationTests/AnomalyDetectionTests.cs
@@ -63,11 +63,11 @@ public class AnomalyDetectionTests
         var detector = new RollingThresholdDetector(Options.Create(settings), cache);
 
         // Trigger spike on /r1 for client "c"
-        detector.Observe(new RequestFeature("c", 0, 5, "/r1", 200, false), out _);
-        Assert.True(detector.Observe(new RequestFeature("c", 0, 5, "/r1", 200, false), out var reason) && reason == "rps_spike");
+        detector.Observe(new RequestFeature("c", 0, 5, "/r1", 200, false, false, "GET", "/r1"), out _);
+        Assert.True(detector.Observe(new RequestFeature("c", 0, 5, "/r1", 200, false, false, "GET", "/r1"), out var reason) && reason == "rps_spike");
 
         // Same client but different route should not be flagged
-        Assert.False(detector.Observe(new RequestFeature("c", 0, 5, "/r2", 200, false), out _));
+        Assert.False(detector.Observe(new RequestFeature("c", 0, 5, "/r2", 200, false, false, "GET", "/r2"), out _));
     }
 
     /// <summary>

--- a/tests/Gateway.IntegrationTests/FeatureTests.cs
+++ b/tests/Gateway.IntegrationTests/FeatureTests.cs
@@ -32,6 +32,9 @@ public class FeatureTests
                     ["AnomalyDetection:FiveXxThreshold"] = "0",
                     ["AnomalyDetection:WafThreshold"] = "0",
                     ["AnomalyDetection:UaEntropyThreshold"] = "0",
+                    // Override proxy routes to avoid forwarding to a non-existent backend during tests
+                    ["ReverseProxy:Routes:public:Match:Path"] = "/proxy/{**catch-all}",
+                    ["ReverseProxy:Routes:secure:Match:Path"] = "/proxy/secure/{**catch-all}",
                 });
             });
         });


### PR DESCRIPTION
## Summary
- Clamp ML PCA rank to dimensions with variance and handle low-variance training
- Provide explicit route keys in anomaly detection tests
- Override proxy routes in integration tests to avoid forwarding to non-existent backend

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c67e1b608326a76db2e95ef2ea47