### PR TITLE
Handle constant feature values in ML detector

### DIFF
--- a/src/gateway/Features/MlAnomalyDetector.cs
+++ b/src/gateway/Features/MlAnomalyDetector.cs
@@ -238,9 +238,11 @@ public class MlAnomalyDetector : IAnomalyDetector, IDisposable
             Oversampling = Math.Min(3, rank)
         };
 
-        return _ml.Transforms
-                  .NormalizeMeanVariance(featureCol)
-                  .Append(_ml.AnomalyDetection.Trainers.RandomizedPca(pca));
+        // NormalizeMeanVariance can produce NaNs when a slot has zero variance
+        // but a non-zero mean. Randomized PCA already centers the data when
+        // EnsureZeroMean=true, so we skip explicit normalization to avoid NaNs
+        // from constant feature values.
+        return _ml.AnomalyDetection.Trainers.RandomizedPca(pca);
     }
 
     private void CalibrateFallback(System.Collections.Generic.IEnumerable<AnomalyVector> data)


### PR DESCRIPTION
## Summary
- avoid NaNs during PCA training when features are constant by removing explicit normalization in the ML detector

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c857b4e483268a171e15e8bfe067