### PR TITLE
Handle ML fallback when only one feature varies

### DIFF
--- a/src/gateway/Features/MlAnomalyDetector.cs
+++ b/src/gateway/Features/MlAnomalyDetector.cs
@@ -113,8 +113,17 @@ public class MlAnomalyDetector : IAnomalyDetector, IDisposable
             return;
         }
 
-        // PCA pipeline with safe rank based on schema dimension and actual variance
+        // If only a single feature has variance, PCA offers no reconstruction error;
+        // fall back to simple RPS-based thresholding instead.
         var activeDim = NonZeroVarianceDims(data);
+        if (activeDim <= 1)
+        {
+            CalibrateFallback(data);
+            _trained = true;
+            return;
+        }
+
+        // PCA pipeline with safe rank based on schema dimension and actual variance
         var pipeline = BuildPcaPipeline(dv, activeDim);
         var model = pipeline.Fit(dv);
 
@@ -152,17 +161,25 @@ public class MlAnomalyDetector : IAnomalyDetector, IDisposable
         var dv = _ml.Data.LoadFromEnumerable(data);
         var varOk = Variance(data) >= _settings.MinVarianceGuard;
 
-        // If we are in fallback and data still has low variance, just recalibrate threshold on RPS.
-        if (_fallbackActive && !varOk)
+        // If we are in fallback mode
+        if (_fallbackActive)
         {
-            CalibrateFallback(data);
-            return;
-        }
+            // and variance is still too low, just recalibrate threshold on RPS.
+            if (!varOk)
+            {
+                CalibrateFallback(data);
+                return;
+            }
 
-        // If we are in fallback and now variance is OK -> switch to PCA.
-        if (_fallbackActive && varOk)
-        {
+            // Even with variance, if only one dimension varies, PCA offers no benefit.
             var activeDim2 = NonZeroVarianceDims(data);
+            if (activeDim2 <= 1)
+            {
+                CalibrateFallback(data);
+                return;
+            }
+
+            // Otherwise switch to PCA.
             var pipeline = BuildPcaPipeline(dv, activeDim2);
             var model = pipeline.Fit(dv);
 
@@ -188,6 +205,14 @@ public class MlAnomalyDetector : IAnomalyDetector, IDisposable
 
         // PCA retrain
         var activeDim = NonZeroVarianceDims(data);
+        if (activeDim <= 1)
+        {
+            // Degenerated to single-dimension variance: switch to fallback.
+            CalibrateFallback(data);
+            _fallbackActive = true;
+            return;
+        }
+
         var pcaPipeline = BuildPcaPipeline(dv, activeDim);
         var pcaModel = pcaPipeline.Fit(dv);
 
@@ -238,9 +263,11 @@ public class MlAnomalyDetector : IAnomalyDetector, IDisposable
             Oversampling = Math.Min(3, rank)
         };
 
-        return _ml.Transforms
-                  .NormalizeMeanVariance(featureCol)
-                  .Append(_ml.AnomalyDetection.Trainers.RandomizedPca(pca));
+        // NormalizeMeanVariance can produce NaNs when a slot has zero variance
+        // but a non-zero mean. Randomized PCA already centers the data when
+        // EnsureZeroMean=true, so we skip explicit normalization to avoid NaNs
+        // from constant feature values.
+        return _ml.AnomalyDetection.Trainers.RandomizedPca(pca);
     }
 
     private void CalibrateFallback(System.Collections.Generic.IEnumerable<AnomalyVector> data)


### PR DESCRIPTION
## Summary
- avoid zero-score PCA by falling back to RPS threshold when only a single feature varies
- test unsupported IsolationForest configuration
- add regression tests for constant features and sliding-window retraining

## Testing
- `dotnet test --no-build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c857b4e483268a171e15e8bfe067