### PR TITLE
Fix nullability issues in detector components

### DIFF
--- a/src/gateway/Features/ModelHolder.cs
+++ b/src/gateway/Features/ModelHolder.cs
@@ -13,7 +13,7 @@ public class ModelHolder
     public ObjectPool<PredictionEngine<AnomalyVector, AnomalyPrediction>>? Pool => Volatile.Read(ref _pool);
     public double Threshold => Volatile.Read(ref _threshold);
 
-    public void Swap(ObjectPool<PredictionEngine<AnomalyVector, AnomalyPrediction>> pool, double threshold)
+    public void Swap(ObjectPool<PredictionEngine<AnomalyVector, AnomalyPrediction>>? pool, double threshold)
     {
         Interlocked.Exchange(ref _pool, pool);
         Interlocked.Exchange(ref _threshold, threshold);

--- a/src/gateway/Features/RollingThresholdDetector.cs
+++ b/src/gateway/Features/RollingThresholdDetector.cs
@@ -20,7 +20,7 @@ public class RollingThresholdDetector : IAnomalyDetector
         var key = (feature.ClientId ?? "unknown", feature.RouteKey);
         var now = DateTime.UtcNow;
 
-        var window = _cache.GetOrCreate(key, entry =>
+        var window = _cache.GetOrCreate<Window>(key, entry =>
         {
             entry.SlidingExpiration = TimeSpan.FromMinutes(_settings.WindowTtlMinutes);
             return new Window(_settings.RpsWindowSeconds, _settings.ErrorWindowSeconds);


### PR DESCRIPTION
## Summary
- ensure memory cache GetOrCreate returns typed Window to avoid null reference
- allow ModelHolder to accept null pools for fallback mode

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d5e6fc84832690ec292556be2b67