### PR TITLE
Handle null window from cache

### DIFF
--- a/src/gateway/Features/RollingThresholdDetector.cs
+++ b/src/gateway/Features/RollingThresholdDetector.cs
@@ -24,7 +24,7 @@ public class RollingThresholdDetector : IAnomalyDetector
         {
             entry.SlidingExpiration = TimeSpan.FromMinutes(_settings.WindowTtlMinutes);
             return new Window(_settings.RpsWindowSeconds, _settings.ErrorWindowSeconds);
-        });
+        }) ?? throw new InvalidOperationException("Failed to create cache window.");
 
         window.Add(feature, now);
 


### PR DESCRIPTION
## Summary
- ensure MemoryCache GetOrCreate in RollingThresholdDetector never returns null by throwing

## Testing
- `dotnet build --configuration Release --no-restore /p:TreatWarningsAsErrors=true` *(fails: command not found)*
- `apt-get update` *(fails: repository 'noble' not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d8daba248326bf5e8ee2857be74f