### PR TITLE
Use logging builder for OpenTelemetry

### DIFF
--- a/src/gateway/ServiceConfigurationExtensions.cs
+++ b/src/gateway/ServiceConfigurationExtensions.cs
@@ -112,9 +112,7 @@ public static class ServiceConfigurationExtensions
         });
         services.AddHostedService<FeatureConsumerService>();
 
-
-        var builder = WebApplication.CreateBuilder();
-        builder.Logging.AddOpenTelemetry(options =>
+        loggingBuilder.AddOpenTelemetry(options =>
         {
             options.IncludeScopes = true;
             options.IncludeFormattedMessage = true;


### PR DESCRIPTION
## Summary
- configure OpenTelemetry logging via provided `ILoggingBuilder`
- avoid creating a second `WebApplication` builder

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f68f014832694240a69c85e97f2