### PR TITLE
Clear configuration sources in gateway factory helpers

### DIFF
--- a/tests/Gateway.IntegrationTests/FeatureTests.cs
+++ b/tests/Gateway.IntegrationTests/FeatureTests.cs
@@ -25,6 +25,7 @@ public class FeatureTests
         {
             builder.ConfigureAppConfiguration((ctx, config) =>
             {
+                config.Sources.Clear();
                 config.AddInMemoryCollection(new Dictionary<string, string?>
                 {
                     ["AnomalyDetection:RpsThreshold"] = "0",

--- a/tests/Gateway.IntegrationTests/PingProxyTests.cs
+++ b/tests/Gateway.IntegrationTests/PingProxyTests.cs
@@ -37,6 +37,7 @@ public class PingProxyTests
                 b.ConfigureAppConfiguration((_, cfg) =>
                 {
                     // Override YARP configuration
+                    cfg.Sources.Clear();
                     cfg.AddInMemoryCollection(new Dictionary<string, string?>
                     {
                         ["ReverseProxy:Clusters:backend:Destinations:d1:Address"] = backendUrl.EndsWith("/") ? backendUrl : backendUrl + "/",

--- a/tests/Gateway.IntegrationTests/RateLimitingTests.cs
+++ b/tests/Gateway.IntegrationTests/RateLimitingTests.cs
@@ -34,6 +34,7 @@ public class RateLimitingTests
                 builder.UseEnvironment("Testing");
                 builder.ConfigureAppConfiguration((_, cfg) =>
                 {
+                    cfg.Sources.Clear();
                     cfg.AddInMemoryCollection(new Dictionary<string, string?>
                     {
                         ["RateLimiting:DefaultRpm"] = "2",

--- a/tests/Gateway.IntegrationTests/ReliabilityTests.cs
+++ b/tests/Gateway.IntegrationTests/ReliabilityTests.cs
@@ -60,6 +60,7 @@ public class ReliabilityTests
                 b.UseEnvironment("Testing");
                 b.ConfigureAppConfiguration((_, cfg) =>
                 {
+                    cfg.Sources.Clear();
                     cfg.AddInMemoryCollection(baseConfig);
                 });
             });

--- a/tests/Gateway.IntegrationTests/SecurityTests.cs
+++ b/tests/Gateway.IntegrationTests/SecurityTests.cs
@@ -73,7 +73,7 @@ public class SecurityTests
 
             // ---- Auth (verranno sovrascritti nei singoli test) ----
             ["Auth:JwtKey"] = "dev-secret",
-            ["Auth:ApiKeyHash"] = Hash(DEV_API_KEY) // placeholder: ogni test può override
+            ["Auth:ApiKeyHash"] = Hash(DEV_API_KEY) // placeholder: ogni test puÃ² override
         };
 
         if (extra is not null)
@@ -88,6 +88,7 @@ public class SecurityTests
                 b.UseEnvironment("Testing");
                 b.ConfigureAppConfiguration((_, cfg) =>
                 {
+                    cfg.Sources.Clear();
                     cfg.AddInMemoryCollection(baseConfig);
                 });
             });
@@ -248,7 +249,7 @@ public class SecurityTests
             });
 
         var client = factory.CreateClient();
-        // L’handler calcola l’hash: serve plaintext qui
+        // LÂ’handler calcola lÂ’hash: serve plaintext qui
         client.DefaultRequestHeaders.Add("X-API-Key", DEV_API_KEY);
 
         var resp = await client.GetAsync("/api/secure/ping");

--- a/tests/Gateway.IntegrationTests/WafTests.cs
+++ b/tests/Gateway.IntegrationTests/WafTests.cs
@@ -16,6 +16,7 @@ public class WafTests
                 {
                     builder.ConfigureAppConfiguration((_, cfg) =>
                     {
+                        cfg.Sources.Clear();
                         cfg.AddInMemoryCollection(extra);
                     });
                 }


### PR DESCRIPTION
## Summary
- Clear configuration sources before adding in-memory settings in `CreateGatewayFactory` and other gateway test helpers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b053b85d788326be6d1c945531f8dd