### PR TITLE
Inject API key store into authentication handler

### DIFF
--- a/src/gateway/Security/ApiKeyAuthenticationHandler.cs
+++ b/src/gateway/Security/ApiKeyAuthenticationHandler.cs
@@ -4,27 +4,23 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
+using Gateway.ControlPlane.Stores;
 
 namespace Gateway.Security;
-
-public sealed class ApiKeyValidationOptions
-{
-    public string Hash { get; set; } = "";
-}
 
 public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     public const string HeaderName = "X-API-Key";
-    private readonly IOptionsMonitor<ApiKeyValidationOptions> _options;
+    private readonly IApiKeyStore _store;
 
     public ApiKeyAuthenticationHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
         UrlEncoder encoder,
-        IOptionsMonitor<ApiKeyValidationOptions> validationOptions)
+        IApiKeyStore store)
         : base(options, logger, encoder)
     {
-        _options = validationOptions;
+        _store = store;
     }
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -33,22 +29,26 @@ public sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<Authenti
             return Task.FromResult(AuthenticateResult.NoResult());
 
         var provided = values.FirstOrDefault();
-        var expectedHash = _options.CurrentValue.Hash;
 
-        if (string.IsNullOrEmpty(provided) || string.IsNullOrEmpty(expectedHash))
+        if (string.IsNullOrEmpty(provided))
             return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));
 
-        var providedHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(provided)));
-        var providedBytes = Convert.FromHexString(providedHash);
-        var expectedBytes = Convert.FromHexString(expectedHash);
+        var providedBytes = SHA256.HashData(Encoding.UTF8.GetBytes(provided));
 
-        if (CryptographicOperations.FixedTimeEquals(providedBytes, expectedBytes))
+        foreach (var key in _store.GetAll())
         {
-            var claims = new[] { new Claim("ApiKey", "Valid") };
-            var identity = new ClaimsIdentity(claims, Scheme.Name);
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, Scheme.Name);
-            return Task.FromResult(AuthenticateResult.Success(ticket));
+            if (string.IsNullOrEmpty(key.Hash))
+                continue;
+
+            var expectedBytes = Convert.FromHexString(key.Hash);
+            if (CryptographicOperations.FixedTimeEquals(providedBytes, expectedBytes))
+            {
+                var claims = new[] { new Claim("ApiKey", "Valid") };
+                var identity = new ClaimsIdentity(claims, Scheme.Name);
+                var principal = new ClaimsPrincipal(identity);
+                var ticket = new AuthenticationTicket(principal, Scheme.Name);
+                return Task.FromResult(AuthenticateResult.Success(ticket));
+            }
         }
 
         return Task.FromResult(AuthenticateResult.Fail("Invalid API Key"));

--- a/src/gateway/ServiceConfigurationExtensions.cs
+++ b/src/gateway/ServiceConfigurationExtensions.cs
@@ -96,15 +96,6 @@ public static class ServiceConfigurationExtensions
             }
             return store;
         });
-        services.AddSingleton<IApiKeyStore>(sp =>
-        {
-            var cfg = sp.GetRequiredService<IConfiguration>();
-            var store = new InMemoryApiKeyStore();
-            var hash = cfg["Auth:ApiKeyHash"];
-            if (!string.IsNullOrEmpty(hash))
-                store.Add(new ApiKeyRecord { Id = Guid.NewGuid().ToString(), Hash = hash, Plan = string.Empty });
-            return store;
-        });
         services.AddSingleton<IAuditLog, InMemoryAuditLog>();
         services.AddSingleton<DynamicProxyConfigProvider>();
         services.AddSingleton<IProxyConfigProvider>(sp => sp.GetRequiredService<DynamicProxyConfigProvider>());
@@ -144,6 +135,15 @@ public static class ServiceConfigurationExtensions
         .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(ApiKeyScheme, options =>
         {
             options.ClaimsIssuer = ApiKeyScheme;
+        })
+        .Services.AddSingleton<IApiKeyStore>(sp =>
+        {
+            var cfg = sp.GetRequiredService<IConfiguration>();
+            var store = new InMemoryApiKeyStore();
+            var hash = cfg["Auth:ApiKeyHash"];
+            if (!string.IsNullOrEmpty(hash))
+                store.Add(new ApiKeyRecord { Id = Guid.NewGuid().ToString(), Hash = hash, Plan = string.Empty });
+            return store;
         });
 
         // Authorization


### PR DESCRIPTION
## Summary
- inject API key store into authentication handler and validate requests against stored hashes
- register API key store when configuring authentication scheme

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0579e412c8326a423fa576e788b8b