### PR TITLE
Ensure reverse proxy defaults for feature tests

### DIFF
--- a/tests/Gateway.IntegrationTests/FeatureTests.cs
+++ b/tests/Gateway.IntegrationTests/FeatureTests.cs
@@ -34,8 +34,11 @@ public class FeatureTests
                     ["AnomalyDetection:WafThreshold"] = "0",
                     ["AnomalyDetection:UaEntropyThreshold"] = "0",
                     // Override proxy routes to avoid forwarding to a non-existent backend during tests
+                    ["ReverseProxy:Routes:public:ClusterId"] = "backend",
                     ["ReverseProxy:Routes:public:Match:Path"] = "/proxy/{**catch-all}",
+                    ["ReverseProxy:Routes:secure:ClusterId"] = "backend",
                     ["ReverseProxy:Routes:secure:Match:Path"] = "/proxy/secure/{**catch-all}",
+                    ["ReverseProxy:Clusters:backend:Destinations:d1:Address"] = "http://localhost:5005/",
                 });
             });
         });


### PR DESCRIPTION
## Summary
- Add explicit backend cluster and destination in `FeatureTests` in-memory configuration
- Prevent reverse proxy startup error when config sources are cleared

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0546a0ce48326bc31eca50d179e96