### PR TITLE
Fix integration test configuration for proxy and rate limiting

### DIFF
--- a/tests/Gateway.IntegrationTests/PingProxyTests.cs
+++ b/tests/Gateway.IntegrationTests/PingProxyTests.cs
@@ -43,7 +43,7 @@ public class PingProxyTests
                         ["ReverseProxy:Clusters:backend:Destinations:d1:Address"] = backendUrl.EndsWith("/") ? backendUrl : backendUrl + "/",
                         // Explicit configuration
                         ["ReverseProxy:Routes:api:ClusterId"] = "backend",
-                        ["ReverseProxy:Routes:api:Match:Path"] = "/public/{**catch-all}",
+                        ["ReverseProxy:Routes:api:Match:Path"] = "/api/{**catch-all}",
                         ["ReverseProxy:Routes:api:Transforms:0:PathRemovePrefix"] = "/api"
                     });
                 });

--- a/tests/Gateway.IntegrationTests/RateLimitingTests.cs
+++ b/tests/Gateway.IntegrationTests/RateLimitingTests.cs
@@ -37,6 +37,7 @@ public class RateLimitingTests
                     cfg.Sources.Clear();
                     cfg.AddInMemoryCollection(new Dictionary<string, string?>
                     {
+                        ["Auth:JwtKey"] = JWT_KEY,
                         ["RateLimiting:DefaultRpm"] = "2",
                         ["RateLimiting:Plans:gold"] = "4"
                     });


### PR DESCRIPTION
## Summary
- Fix proxy route path in PingProxy test
- Configure JWT key in rate limiting tests for proper client identification

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b059dd39148326a6e0224c72ec6873