### PR TITLE
Handle missing summarizer base URL

### DIFF
--- a/src/gateway/ServiceConfigurationExtensions.cs
+++ b/src/gateway/ServiceConfigurationExtensions.cs
@@ -201,7 +201,10 @@ public static class ServiceConfigurationExtensions
 
         services.AddHttpClient<Gateway.AI.ISummarizerClient, Gateway.AI.SummarizerHttpClient>(http =>
         {
-            http.BaseAddress = new Uri(configuration["Summarizer:BaseUrl"] ?? "http://localhost:5290");
+            var baseUrl = configuration["Summarizer:BaseUrl"];
+            if (string.IsNullOrWhiteSpace(baseUrl))
+                baseUrl = "http://localhost:5290";
+            http.BaseAddress = new Uri(baseUrl);
             http.DefaultRequestHeaders.Add("X-Internal-Key", configuration["Summarizer:InternalKey"] ?? "dev");
         });
         services.AddHostedService<FeatureConsumerService>();


### PR DESCRIPTION
## Summary
- ensure Summarizer client uses localhost base URL when configuration is missing

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05e53108c8326b341d69d8c3b8577