### PR TITLE
Specify Summarizer BaseUrl for rate limiting tests

### DIFF
--- a/tests/Gateway.IntegrationTests/RateLimitingTests.cs
+++ b/tests/Gateway.IntegrationTests/RateLimitingTests.cs
@@ -32,6 +32,7 @@ public class RateLimitingTests
             {
                 builder.UseEnvironment("Testing");
                 builder.UseSetting("Auth:JwtKey", JWT_KEY);
+                builder.UseSetting("Summarizer:BaseUrl", "http://localhost:5290");
                 builder.UseSetting("RateLimiting:DefaultRpm", "2");
                 builder.UseSetting("RateLimiting:Plans:gold", "4");
             });


### PR DESCRIPTION
## Summary
- configure Summarizer:BaseUrl for rate limiting test WebApplicationFactory

## Testing
- `dotnet test tests/Gateway.IntegrationTests --filter RateLimiting` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b05e5421c08326bc4cff8730d2e94c