### PR TITLE
feat: support configurable default rate limit

### DIFF
--- a/src/gateway/ControlPlane/Stores/InMemoryRateLimitStore.cs
+++ b/src/gateway/ControlPlane/Stores/InMemoryRateLimitStore.cs
@@ -5,6 +5,7 @@ namespace Gateway.ControlPlane.Stores;
 
 public interface IRateLimitPlanStore
 {
+    const string DefaultPlan = "__default__";
     IEnumerable<RateLimitPlan> GetAll();
     (RateLimitPlan plan, string etag) Add(RateLimitPlan plan);
     bool TryUpdate(string plan, RateLimitPlan updated, string? etag, out string newEtag, out RateLimitPlan? before);

--- a/src/gateway/ServiceConfigurationExtensions.cs
+++ b/src/gateway/ServiceConfigurationExtensions.cs
@@ -76,6 +76,8 @@ public static class ServiceConfigurationExtensions
         {
             var cfg = sp.GetRequiredService<IConfiguration>();
             var store = new InMemoryRateLimitStore();
+            var defaultRpm = cfg.GetValue<int>("RateLimiting:DefaultRpm", 100);
+            store.Add(new RateLimitPlan { Plan = IRateLimitPlanStore.DefaultPlan, Rpm = defaultRpm });
             var plans = cfg.GetSection("RateLimiting:Plans").GetChildren();
             foreach (var p in plans)
             {


### PR DESCRIPTION
## Summary
- provide default rate limit plan stored as `__default__`
- middleware loads default rate limit from plan store rather than IConfiguration
- allow updating default plan via control plane and prevent deleting it
- test default plan update and delete behavior

## Testing
- `dotnet test` *(failed: command not found)*
- `apt-get update` *(failed: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0601a59088326867653dd8792484b