### PR TITLE
Map Prometheus endpoint when meter provider is available

### DIFF
--- a/src/gateway/Program.cs
+++ b/src/gateway/Program.cs
@@ -71,8 +71,8 @@ app.MapPost("/api/echo", async (HttpContext ctx) =>
 });
 app.MapReverseProxy();
 var meterProvider = app.Services.GetService<MeterProvider>();
-if (meterProvider is not null)
-    app.MapPrometheusScrapingEndpoint();
+if (meterProvider != null)
+    app.MapPrometheusScrapingEndpoint(meterProvider);
 app.MapControllers();
 
 app.Run();


### PR DESCRIPTION
## Summary
- Map Prometheus scraping endpoint only when a MeterProvider is registered

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test tests/Gateway.IntegrationTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b061e84c58832681c57d91179f01d3