### PR TITLE
Handle quoted ETag headers in control plane

### DIFF
--- a/src/gateway/ControlPlane/Controllers/ApiKeysController.cs
+++ b/src/gateway/ControlPlane/Controllers/ApiKeysController.cs
@@ -21,7 +21,7 @@ public sealed class ApiKeysController : ControllerBase
     public ActionResult<ApiKeyRecord> Create(ApiKeyRecord key)
     {
         var (created, etag) = _store.Add(key);
-        Response.Headers.ETag = etag;
+        Response.Headers.ETag = $"\"{etag}\"";
         _audit.Log(User.Identity?.Name ?? "anon", "apikey", created.Id, "create", null, created);
         return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
     }
@@ -31,9 +31,10 @@ public sealed class ApiKeysController : ControllerBase
     {
         if (!Request.Headers.TryGetValue("If-Match", out var etag))
             return BadRequest();
-        if (!_store.TryUpdate(id, key with { Id = id }, etag!, out var newEtag, out var before))
+        var match = etag!.ToString().Trim('"');
+        if (!_store.TryUpdate(id, key with { Id = id }, match, out var newEtag, out var before))
             return Conflict();
-        Response.Headers.ETag = newEtag;
+        Response.Headers.ETag = $"\"{newEtag}\"";
         _audit.Log(User.Identity?.Name ?? "anon", "apikey", id, "update", before, key);
         return NoContent();
     }
@@ -43,7 +44,8 @@ public sealed class ApiKeysController : ControllerBase
     {
         if (!Request.Headers.TryGetValue("If-Match", out var etag))
             return BadRequest();
-        if (!_store.TryRemove(id, etag!, out var before))
+        var match = etag!.ToString().Trim('"');
+        if (!_store.TryRemove(id, match, out var before))
             return Conflict();
         _audit.Log(User.Identity?.Name ?? "anon", "apikey", id, "delete", before, null);
         return NoContent();

--- a/src/gateway/ControlPlane/Controllers/RoutesController.cs
+++ b/src/gateway/ControlPlane/Controllers/RoutesController.cs
@@ -21,7 +21,7 @@ public sealed class RoutesController : ControllerBase
     public ActionResult<RouteConfig> Create(RouteConfig route)
     {
         var (created, etag) = _store.Add(route);
-        Response.Headers.ETag = etag;
+        Response.Headers.ETag = $"\"{etag}\"";
         _audit.Log(User.Identity?.Name ?? "anon", "route", created.Id, "create", null, created);
         return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
     }
@@ -31,9 +31,10 @@ public sealed class RoutesController : ControllerBase
     {
         if (!Request.Headers.TryGetValue("If-Match", out var etag))
             return BadRequest();
-        if (!_store.TryUpdate(id, route with { Id = id }, etag!, out var newEtag, out var before))
+        var match = etag!.ToString().Trim('"');
+        if (!_store.TryUpdate(id, route with { Id = id }, match, out var newEtag, out var before))
             return Conflict();
-        Response.Headers.ETag = newEtag;
+        Response.Headers.ETag = $"\"{newEtag}\"";
         _audit.Log(User.Identity?.Name ?? "anon", "route", id, "update", before, route);
         return NoContent();
     }
@@ -43,7 +44,8 @@ public sealed class RoutesController : ControllerBase
     {
         if (!Request.Headers.TryGetValue("If-Match", out var etag))
             return BadRequest();
-        if (!_store.TryRemove(id, etag!, out var before))
+        var match = etag!.ToString().Trim('"');
+        if (!_store.TryRemove(id, match, out var before))
             return Conflict();
         _audit.Log(User.Identity?.Name ?? "anon", "route", id, "delete", before, null);
         return NoContent();


### PR DESCRIPTION
## Summary
- ensure ETag values are quoted in create and update responses
- strip quotes from If-Match headers before store comparison

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b061ea8d608326be43646f1f631d1b