### PR TITLE
Load default rate limit plan from configuration

### DIFF
--- a/src/gateway/ServiceConfigurationExtensions.cs
+++ b/src/gateway/ServiceConfigurationExtensions.cs
@@ -76,6 +76,9 @@ public static class ServiceConfigurationExtensions
         {
             var cfg = sp.GetRequiredService<IConfiguration>();
             var store = new InMemoryRateLimitStore();
+            var defaultRpm = cfg.GetValue<int?>("RateLimiting:DefaultRpm");
+            if (defaultRpm.HasValue)
+                store.Add(new RateLimitPlan { Plan = IRateLimitPlanStore.DefaultPlan, Rpm = defaultRpm.Value });
             var plans = cfg.GetSection("RateLimiting:Plans").GetChildren();
             foreach (var p in plans)
             {


### PR DESCRIPTION
## Summary
- add default rate limit plan using `RateLimiting:DefaultRpm`

## Testing
- `dotnet test tests/Gateway.IntegrationTests -l "console;verbosity=normal"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b063eb9234832699ddd470f1f7e8ed