### PR TITLE
Use fallback JWT key when configuration missing

### DIFF
--- a/src/gateway/ServiceConfigurationExtensions.cs
+++ b/src/gateway/ServiceConfigurationExtensions.cs
@@ -124,7 +124,7 @@ public static class ServiceConfigurationExtensions
         })
         .AddJwtBearer(options =>
         {
-            var jwtKey = configuration["Auth:JwtKey"] ?? "dev-secret";
+            var jwtKey = string.IsNullOrWhiteSpace(configuration["Auth:JwtKey"]) ? "dev-secret" : configuration["Auth:JwtKey"];
             options.TokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = false,


### PR DESCRIPTION
## Summary
- Provide default `dev-secret` when `Auth:JwtKey` is missing to avoid exceptions

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b0651d6ac08326a9a8dfa36682a4a3