### PR TITLE
Clamp PCA rank below active feature count

### DIFF
--- a/src/gateway/Features/MlAnomalyDetector.cs
+++ b/src/gateway/Features/MlAnomalyDetector.cs
@@ -251,7 +251,14 @@ public class MlAnomalyDetector : IAnomalyDetector, IDisposable
         var vecType = dv.Schema[featureCol].Type as VectorDataViewType;
         var dim = vecType?.Size ?? 0;
         var wanted = Math.Min(5, dim);
-        var rank = Math.Max(1, Math.Min(wanted, activeDim > 0 ? activeDim : dim));
+
+        // Using a rank equal to the number of active dimensions perfectly spans the
+        // training data subspace and yields zero reconstruction error for any point
+        // lying in that subspace. This effectively disables anomaly detection for
+        // large-but-in-subspace deviations. Clamp the rank to strictly less than the
+        // number of varying dimensions so outliers incur reconstruction error.
+        var capped = activeDim > 1 ? activeDim - 1 : activeDim;
+        var rank = Math.Max(1, Math.Min(wanted, capped > 0 ? capped : dim));
 
         var pca = new RandomizedPcaTrainer.Options
         {


### PR DESCRIPTION
## Summary
- prevent PCA model from using full rank so reconstruction errors can flag outliers

## Testing
- `dotnet test tests/Gateway.IntegrationTests -c Release --filter "AnomalyDetectionTests.MlDetector_PersistsAndReloads_PcaModel" -v n` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b068df588883268c7607ff9c6f8804