### PR TITLE
Use list for transform configs and add stack overflow test

### DIFF
--- a/src/gateway/ControlPlane/DynamicProxyConfigProvider.cs
+++ b/src/gateway/ControlPlane/DynamicProxyConfigProvider.cs
@@ -33,13 +33,10 @@ public sealed class DynamicProxyConfigProvider : IProxyConfigProvider
                 Match = new RouteMatch { Path = r.Path },
                 AuthorizationPolicy = r.AuthorizationPolicy,
                 Transforms = string.IsNullOrEmpty(r.PathRemovePrefix)
-                    ? null
-                    : new[]
+                    ? Array.Empty<Dictionary<string, string>>()
+                    : new List<Dictionary<string, string>>
                     {
-                        new Dictionary<string, string>
-                        {
-                            ["PathRemovePrefix"] = r.PathRemovePrefix!
-                        }
+                        new() { ["PathRemovePrefix"] = r.PathRemovePrefix! }
                     }
             });
             clusters.Add(new ClusterConfig

--- a/tests/Gateway.IntegrationTests/ControlPlaneTests.cs
+++ b/tests/Gateway.IntegrationTests/ControlPlaneTests.cs
@@ -45,6 +45,25 @@ public class ControlPlaneTests
     }
 
     [Fact]
+    public async Task PathRemovePrefix_Route_Completes()
+    {
+        using var factory = new WebApplicationFactory<Program>();
+        var client = factory.CreateClient();
+        var route = new RouteConfig
+        {
+            Id = "rpp",
+            Path = "/rpp/{**catch-all}",
+            Destination = "http://e",
+            PathRemovePrefix = "/rpp"
+        };
+        var create = await client.PostAsJsonAsync("/cp/routes", route);
+        Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+
+        var resp = await client.GetAsync("/rpp/test");
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+    }
+
+    [Fact]
     public async Task RateLimits_Etag_And_Audit_Work()
     {
         using var factory = new WebApplicationFactory<Program>();


### PR DESCRIPTION
## Summary
- Build YARP route config with `List<Dictionary<string,string>>` and `Array.Empty` to avoid recursive enumerator issues
- Add integration test posting a route with `PathRemovePrefix` to ensure proxy calls complete

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0690d99fc8326b3a08b07dac07c82