### PR TITLE
test: isolate gateway integration tests from production routes

### DIFF
--- a/tests/Gateway.IntegrationTests/ControlPlaneTests.cs
+++ b/tests/Gateway.IntegrationTests/ControlPlaneTests.cs
@@ -10,7 +10,7 @@ public class ControlPlaneTests
     [Fact]
     public async Task Routes_Etag_And_Audit_Work()
     {
-        using var factory = new WebApplicationFactory<Program>();
+        using var factory = new GatewayFactory();
         var client = factory.CreateClient();
         var route = new RouteConfig { Id = "r1", Path = "/r1", Destination = "http://e" };
         var create = await client.PostAsJsonAsync("/cp/routes", route);
@@ -47,7 +47,7 @@ public class ControlPlaneTests
     [Fact]
     public async Task PathRemovePrefix_Route_Completes()
     {
-        using var factory = new WebApplicationFactory<Program>();
+        using var factory = new GatewayFactory();
         var client = factory.CreateClient();
         var route = new RouteConfig
         {
@@ -66,7 +66,7 @@ public class ControlPlaneTests
     [Fact]
     public async Task RateLimits_Etag_And_Audit_Work()
     {
-        using var factory = new WebApplicationFactory<Program>();
+        using var factory = new GatewayFactory();
         var client = factory.CreateClient();
         var plan = new RateLimitPlan { Plan = "gold", Rpm = 100 };
         var create = await client.PostAsJsonAsync("/cp/ratelimits", plan);
@@ -97,7 +97,7 @@ public class ControlPlaneTests
     [Fact]
     public async Task Default_RateLimit_Can_Be_Updated_But_Not_Deleted()
     {
-        using var factory = new WebApplicationFactory<Program>();
+        using var factory = new GatewayFactory();
         var client = factory.CreateClient();
 
         var get = await client.GetAsync("/cp/ratelimits/default");
@@ -120,7 +120,7 @@ public class ControlPlaneTests
     [Fact]
     public async Task Waf_Etag_And_Audit_Work()
     {
-        using var factory = new WebApplicationFactory<Program>();
+        using var factory = new GatewayFactory();
         var client = factory.CreateClient();
         var toggle = new WafToggle { Rule = "xss", Enabled = true };
         var create = await client.PostAsJsonAsync("/cp/waf", toggle);
@@ -151,7 +151,7 @@ public class ControlPlaneTests
     [Fact]
     public async Task ApiKeys_Etag_And_Audit_Work()
     {
-        using var factory = new WebApplicationFactory<Program>();
+        using var factory = new GatewayFactory();
         var client = factory.CreateClient();
         var key = new ApiKeyRecord { Id = "k1", Hash = "hash", Plan = "basic" };
         var create = await client.PostAsJsonAsync("/cp/apikeys", key);

--- a/tests/Gateway.IntegrationTests/FeatureTests.cs
+++ b/tests/Gateway.IntegrationTests/FeatureTests.cs
@@ -21,7 +21,7 @@ public class FeatureTests
     }
 
     private static WebApplicationFactory<Program> CreateFactory()
-        => new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        => new GatewayFactory().WithWebHostBuilder(builder =>
         {
             builder.ConfigureAppConfiguration((ctx, config) =>
             {

--- a/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
+++ b/tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj
@@ -8,18 +8,24 @@
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 
-	<ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
         <PackageReference Include="coverlet.collector" Version="6.0.2" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
-	</ItemGroup>
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\..\src\gateway\Gateway.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\gateway\Gateway.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.Test.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 	<ItemGroup>
 		<Using Include="Xunit" />

--- a/tests/Gateway.IntegrationTests/GatewayFactory.cs
+++ b/tests/Gateway.IntegrationTests/GatewayFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using System.IO;
+
+namespace Gateway.IntegrationTests;
+
+public class GatewayFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "appsettings.Test.json");
+            config.AddJsonFile(path, optional: true);
+        });
+    }
+}

--- a/tests/Gateway.IntegrationTests/PingProxyTests.cs
+++ b/tests/Gateway.IntegrationTests/PingProxyTests.cs
@@ -11,7 +11,7 @@ public class PingProxyTests
     [Fact]
     public async Task Root_And_Healthz_Work()
     {
-        using var factory = new WebApplicationFactory<Program>();
+        using var factory = new GatewayFactory();
         var client = factory.CreateClient();
         Assert.Equal("AegisAPI Gateway up", await client.GetStringAsync("/"));
         var resp = await client.GetAsync("/healthz");
@@ -30,7 +30,7 @@ public class PingProxyTests
 
         var backendUrl = backendApp.Urls.Single(); // e.g. http://127.0.0.1:51023/
 
-        using var factory = new WebApplicationFactory<Program>()
+        using var factory = new GatewayFactory()
             .WithWebHostBuilder(b =>
             {
                 b.UseEnvironment("Testing");

--- a/tests/Gateway.IntegrationTests/RateLimitingTests.cs
+++ b/tests/Gateway.IntegrationTests/RateLimitingTests.cs
@@ -27,7 +27,7 @@ public class RateLimitingTests
     }
 
     private static WebApplicationFactory<Program> CreateFactory()
-        => new WebApplicationFactory<Program>()
+        => new GatewayFactory()
             .WithWebHostBuilder(builder =>
             {
                 builder.UseEnvironment("Testing");

--- a/tests/Gateway.IntegrationTests/ReliabilityTests.cs
+++ b/tests/Gateway.IntegrationTests/ReliabilityTests.cs
@@ -54,7 +54,7 @@ public class ReliabilityTests
                 baseConfig[kv.Key] = kv.Value;
         }
 
-        return new WebApplicationFactory<Program>()
+        return new GatewayFactory()
             .WithWebHostBuilder(b =>
             {
                 b.UseEnvironment("Testing");

--- a/tests/Gateway.IntegrationTests/SecurityTests.cs
+++ b/tests/Gateway.IntegrationTests/SecurityTests.cs
@@ -82,7 +82,7 @@ public class SecurityTests
                 baseConfig[kv.Key] = kv.Value;
         }
 
-        return new WebApplicationFactory<Program>()
+        return new GatewayFactory()
             .WithWebHostBuilder(b =>
             {
                 b.UseEnvironment("Testing");

--- a/tests/Gateway.IntegrationTests/ValidationTests.cs
+++ b/tests/Gateway.IntegrationTests/ValidationTests.cs
@@ -5,11 +5,11 @@ using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace Gateway.IntegrationTests;
 
-public class ValidationTests : IClassFixture<WebApplicationFactory<Program>>
+public class ValidationTests : IClassFixture<GatewayFactory>
 {
     private readonly HttpClient _client;
 
-    public ValidationTests(WebApplicationFactory<Program> factory)
+    public ValidationTests(GatewayFactory factory)
     {
         _client = factory.CreateClient();
     }

--- a/tests/Gateway.IntegrationTests/WafTests.cs
+++ b/tests/Gateway.IntegrationTests/WafTests.cs
@@ -8,7 +8,7 @@ namespace Gateway.IntegrationTests;
 public class WafTests
 {
     private static WebApplicationFactory<Program> CreateFactory(IDictionary<string, string?>? extra = null)
-        => new WebApplicationFactory<Program>()
+        => new GatewayFactory()
             .WithWebHostBuilder(builder =>
             {
                 builder.UseEnvironment("Testing");

--- a/tests/Gateway.IntegrationTests/appsettings.Test.json
+++ b/tests/Gateway.IntegrationTests/appsettings.Test.json
@@ -1,0 +1,5 @@
+{
+  "ReverseProxy": {
+    "Routes": {}
+  }
+}


### PR DESCRIPTION
## Summary
- add GatewayFactory to load appsettings.Test.json with no ReverseProxy routes
- switch Gateway integration tests to GatewayFactory
- include test settings file in test project output

## Testing
- `dotnet test tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj -c Release` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b06bf70ab48326bc9597c49e6b50ef