### PR TITLE
Add IP fallback for rate limiter

### DIFF
--- a/src/gateway/RateLimiting/ClientRateLimiterMiddleware.cs
+++ b/src/gateway/RateLimiting/ClientRateLimiterMiddleware.cs
@@ -28,8 +28,8 @@ public sealed class ClientRateLimiterMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        var clientId = GetClientId(context);
-        if (clientId is null)
+        var clientId = GetClientId(context) ?? context.Connection.RemoteIpAddress?.ToString();
+        if (string.IsNullOrEmpty(clientId))
         {
             await _next(context);
             return;

--- a/tests/Gateway.IntegrationTests/RateLimitingTests.cs
+++ b/tests/Gateway.IntegrationTests/RateLimitingTests.cs
@@ -89,4 +89,19 @@ public class RateLimitingTests
         Assert.True(statuses.Take(4).All(s => s == HttpStatusCode.OK));
         Assert.Equal(HttpStatusCode.TooManyRequests, statuses.Last());
     }
+
+    [Fact]
+    public async Task Unauthenticated_Client_Is_Rate_Limited_By_IP()
+    {
+        using var factory = CreateFactory();
+        var client = factory.CreateClient();
+
+        var r1 = await client.GetAsync("/");
+        var r2 = await client.GetAsync("/");
+        var r3 = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, r1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, r2.StatusCode);
+        Assert.Equal(HttpStatusCode.TooManyRequests, r3.StatusCode);
+    }
 }


### PR DESCRIPTION
## Summary
- use remote IP as client ID when no other identifier is available
- add integration test to ensure unauthenticated requests are rate-limited

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09dee03588326b2871281d2172a8c