### PR TITLE
Rename JsonValidation middleware method

### DIFF
--- a/src/gateway/Validation/JsonValidationMiddleware.cs
+++ b/src/gateway/Validation/JsonValidationMiddleware.cs
@@ -15,8 +15,7 @@ public class JsonValidationMiddleware
         _schemaRoot = Path.Combine(env.ContentRootPath, "Schemas");
     }
 
-    // Update the usage in Invoke method
-    public async Task Invoke(HttpContext context)
+    public async Task InvokeAsync(HttpContext context)
     {
         if (!context.Request.Path.StartsWithSegments("/api", out var remainder))
         {


### PR DESCRIPTION
## Summary
- remove redundant comment in JsonValidationMiddleware
- rename Invoke to InvokeAsync and ensure middleware registration via UseMiddleware

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b09eb893948326a6c53b92fb82cb0c