### PR TITLE
Remove backend addresses from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,17 @@ curl http://localhost:5000/metrics                      # Prometheus metrics
 
 The Summarizer exposes `POST /ai/summarize` and a `GET /seed/logs` helper that returns a sample `IncidentBundle` for quick experiments.
 
-## Autenticazione
+## Backend configuration
 
-AegisAPI supporta due modalità di autenticazione:
+Backend service addresses are not set in `src/gateway/appsettings.json`.
+In production these values must be provided via environment variables or managed dynamically through the Control Plane.
 
-- **JWT**: inviare un token nell'intestazione `Authorization: Bearer <token>`. Per lo sviluppo, impostare il segreto simmetrico tramite `Auth:JwtKey` in `src/gateway/appsettings.Development.json`.
-- **API key**: inviare la chiave nell'intestazione `X-API-Key: <chiave>`. Per lo sviluppo, configurare `Auth:ApiKeyHash` nello stesso file con l'hash SHA-256 della chiave (`echo -n tua-chiave | sha256sum`).
+## Authentication
+
+AegisAPI supports two authentication modes:
+
+- **JWT**: send a token in the `Authorization: Bearer <token>` header. For development, set the symmetric secret via `Auth:JwtKey` in `src/gateway/appsettings.Development.json`.
+- **API key**: send the key in the `X-API-Key: <key>` header. For development, configure `Auth:ApiKeyHash` in the same file with the SHA-256 hash of the key (`echo -n your-key | sha256sum`).
 
 ### ✨ Features
 

--- a/src/gateway/appsettings.json
+++ b/src/gateway/appsettings.json
@@ -41,7 +41,7 @@
         "LoadBalancingPolicy": "PowerOfTwoChoices",
         "SessionAffinity": { "AffinityKeyName": "gw_", "Enabled": false },
         "Destinations": {
-          "d1": { "Address": "http://localhost:5005/" }
+          "d1": { "Address": "" }
         }
       }
     }


### PR DESCRIPTION
## Summary
- remove backend destination address from appsettings
- note in README to provide backend addresses via environment variables or Control Plane
- translate README to English for consistency

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09ec0e2708326a7f0ec8463f86c0d