### PR TITLE
test: verify WAF rule disabling via control plane

### DIFF
--- a/tests/Gateway.IntegrationTests/WafTests.cs
+++ b/tests/Gateway.IntegrationTests/WafTests.cs
@@ -1,7 +1,9 @@
+using Gateway.ControlPlane.Models;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using System.Net;
+using System.Net.Http.Json;
 
 namespace Gateway.IntegrationTests;
 
@@ -83,5 +85,22 @@ public class WafTests
 
         var resp = await client.GetAsync("/healthz?input=' OR 1=1 --");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Rule_Can_Be_Disabled_Via_ControlPlane()
+    {
+        using var factory = CreateFactory();
+        var client = factory.CreateClient();
+
+        var blocked = await client.GetAsync("/healthz?input=<script>alert(1)</script>");
+        Assert.Equal(HttpStatusCode.Forbidden, blocked.StatusCode);
+
+        var toggle = new WafToggle { Rule = "xss", Enabled = false };
+        var disable = await client.PostAsJsonAsync("/cp/waf", toggle);
+        Assert.Equal(HttpStatusCode.Created, disable.StatusCode);
+
+        var allowed = await client.GetAsync("/healthz?input=<script>alert(1)</script>");
+        Assert.Equal(HttpStatusCode.OK, allowed.StatusCode);
     }
 }


### PR DESCRIPTION
## Summary
- ensure XSS requests are initially blocked
- disable XSS rule through `/cp/waf`
- verify previously blocked request is now allowed

## Testing
- `dotnet test tests/Gateway.IntegrationTests/Gateway.IntegrationTests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b09ecdd48883268b54c04659d2b7be