### PR TITLE
Relax CSP for Swagger

### DIFF
--- a/src/gateway/Program.cs
+++ b/src/gateway/Program.cs
@@ -41,7 +41,8 @@ app.Use(async (ctx, next) =>
     ctx.Response.Headers["X-Frame-Options"] = "DENY";
     ctx.Response.Headers["X-XSS-Protection"] = "1; mode=block";
     ctx.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
-    ctx.Response.Headers["Content-Security-Policy"] = "default-src 'self'";
+    ctx.Response.Headers["Content-Security-Policy"] =
+        "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:";
     await next();
 });
 


### PR DESCRIPTION
## Summary
- allow inline scripts, styles, and websocket connections in CSP for gateway

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ab1425ec8326b0732d0893c73ba0