### PR TITLE
Revamp dashboard metrics with gateway-themed data

### DIFF
--- a/src/ui/dashboard/Hubs/MetricsHub.cs
+++ b/src/ui/dashboard/Hubs/MetricsHub.cs
@@ -12,10 +12,10 @@ public class MetricsHub : Hub
         while (true)
         {
             var metric = new MetricDto(
-                rnd.NextDouble() * 100, // CPU Usage
-                rnd.Next(0, 32000),    // Memory Usage
-                rnd.Next(50, 500),     // Active Users
-                rnd.NextDouble() * 5   // Error Rate
+                rnd.NextDouble() * 100, // Requests per second
+                rnd.NextDouble() * 8,   // UA entropy
+                rnd.Next(0, 20),        // Schema errors
+                rnd.Next(0, 10)         // WAF blocks
             );
 
             await Clients.All.SendAsync("metrics", metric);

--- a/src/ui/dashboard/Models/MetricDto.cs
+++ b/src/ui/dashboard/Models/MetricDto.cs
@@ -1,3 +1,3 @@
 namespace Dashboard.Models;
 
-public record MetricDto(double Cpu, double Memory, int ActiveUsers, double ErrorRate);
+public record MetricDto(double Rps, double UaEntropy, int SchemaErrors, int WafBlocks);

--- a/src/ui/dashboard/Pages/Dashboard.razor
+++ b/src/ui/dashboard/Pages/Dashboard.razor
@@ -2,20 +2,50 @@
 @inject IMetricsService MetricsService
 @inject ISnackbar Snackbar
 
-<MudCard Class="pa-4 ma-4" Elevation="4">
-    <MudText Typo="Typo.h5" Class="mb-2" Bold="true">Live Metrics</MudText>
-    <MudDivider Class="mb-2" />
-    <MudText Typo="Typo.h6">CPU Usage: @cpu.ToString("F1")%</MudText>
-    <MudText Typo="Typo.h6">Memory Usage: @memory.ToString("F0") MB</MudText>
-    <MudText Typo="Typo.h6">Active Users: @activeUsers</MudText>
-    <MudText Typo="Typo.h6">Error Rate: @errorRate.ToString("F2")%</MudText>
-</MudCard>
+<MudGrid Class="pa-4">
+    <MudItem xs="12" sm="6" md="3">
+        <MudCard Class="wow-card pa-4">
+            <MudCardContent Class="text-center">
+                <MudIcon Icon="@Icons.Material.Filled.Speed" Size="Size.Large" />
+                <MudText Typo="Typo.subtitle1">Requests/s</MudText>
+                <MudText Typo="Typo.h4">@rps.ToString("F1")</MudText>
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="3">
+        <MudCard Class="wow-card pa-4">
+            <MudCardContent Class="text-center">
+                <MudIcon Icon="@Icons.Material.Filled.DeviceUnknown" Size="Size.Large" />
+                <MudText Typo="Typo.subtitle1">UA Entropy</MudText>
+                <MudText Typo="Typo.h4">@uaEntropy.ToString("F2")</MudText>
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="3">
+        <MudCard Class="wow-card pa-4">
+            <MudCardContent Class="text-center">
+                <MudIcon Icon="@Icons.Material.Filled.Rule" Size="Size.Large" />
+                <MudText Typo="Typo.subtitle1">Schema Errors</MudText>
+                <MudText Typo="Typo.h4">@schemaErrors</MudText>
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+    <MudItem xs="12" sm="6" md="3">
+        <MudCard Class="wow-card pa-4">
+            <MudCardContent Class="text-center">
+                <MudIcon Icon="@Icons.Material.Filled.Shield" Size="Size.Large" />
+                <MudText Typo="Typo.subtitle1">WAF Blocks</MudText>
+                <MudText Typo="Typo.h4">@wafBlocks</MudText>
+            </MudCardContent>
+        </MudCard>
+    </MudItem>
+</MudGrid>
 
 @code {
-    private double cpu;
-    private double memory;
-    private int activeUsers;
-    private double errorRate;
+    private double rps;
+    private double uaEntropy;
+    private int schemaErrors;
+    private int wafBlocks;
     private CancellationTokenSource? cts;
 
     protected override async Task OnInitializedAsync()
@@ -33,10 +63,10 @@
 
     private Task OnMetric(MetricDto m)
     {
-        cpu = m.Cpu;
-        memory = m.Memory;
-        activeUsers = m.ActiveUsers;
-        errorRate = m.ErrorRate;
+        rps = m.Rps;
+        uaEntropy = m.UaEntropy;
+        schemaErrors = m.SchemaErrors;
+        wafBlocks = m.WafBlocks;
         InvokeAsync(StateHasChanged);
         return Task.CompletedTask;
     }

--- a/src/ui/dashboard/Services/Mock/MockMetricsService.cs
+++ b/src/ui/dashboard/Services/Mock/MockMetricsService.cs
@@ -17,10 +17,10 @@ public class MockMetricsService : IMetricsService
             .Build();
 
         connection.On<MetricDto>("metrics", async m => await handler(new MetricDto(
-            m.Cpu,
-            m.Memory,
-            new Random().Next(50, 500), // Simulated Active Users
-            new Random().NextDouble() * 5 // Simulated Error Rate
+            m.Rps,
+            m.UaEntropy,
+            new Random().Next(0, 20), // Simulated schema errors
+            new Random().Next(0, 10)  // Simulated WAF blocks
         )));
 
         await connection.StartAsync(token);

--- a/src/ui/dashboard/wwwroot/css/app.css
+++ b/src/ui/dashboard/wwwroot/css/app.css
@@ -1,0 +1,9 @@
+.wow-card {
+    background: linear-gradient(135deg, #1e88e5, #42a5f5);
+    color: white;
+    transition: transform 0.3s;
+}
+
+.wow-card:hover {
+    transform: scale(1.05);
+}


### PR DESCRIPTION
## Summary
- Replace CPU/memory metrics with gateway features like requests/sec, UA entropy, schema errors and WAF blocks
- Show metrics in flashy card layout with gradient hover effect
- Keep mock/non-mock separation while updating metric streaming

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b16b9f85648326ab3dc6328ca0794e