### PR TITLE
feat(ui): highlight mock mode

### DIFF
--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -9,7 +9,7 @@
     <title>Dashboard - Alpha Version</title>
     <base href="~/" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-    <link href="css/site.css" rel="stylesheet" />
+    <link href="css/app.css" rel="stylesheet" />
 </head>
 <body>
     <app>

--- a/src/ui/dashboard/Shared/MainLayout.razor
+++ b/src/ui/dashboard/Shared/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @using MudBlazor
+@using Microsoft.Extensions.Configuration
 
 <MudThemeProvider IsDarkMode="true" />
 <MudDialogProvider />
@@ -19,10 +20,17 @@
             @Body
         </MudMainContent>
     </MudLayout>
+    @if (UseMocks)
+    {
+        <div class="mock-banner">MOCK MODE</div>
+    }
 </div>
 
 @code {
     [Inject] NavigationManager Nav { get; set; } = default!;
+    [Inject] IConfiguration Configuration { get; set; } = default!;
+
+    private bool UseMocks => Configuration.GetValue<bool>("UseMocks");
 
     private void HandleKey(KeyboardEventArgs e)
     {

--- a/src/ui/dashboard/wwwroot/css/app.css
+++ b/src/ui/dashboard/wwwroot/css/app.css
@@ -22,3 +22,16 @@
     50% { background-position: 100% 50%; }
     100% { background-position: 0% 50%; }
 }
+
+.mock-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: orange;
+    color: black;
+    text-align: center;
+    padding: 0.5rem 0;
+    font-weight: bold;
+    z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- show a bottom orange banner when the dashboard runs in mock mode
- wire up app.css so custom styles load, including mock banner styling

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, cannot install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b16fcf83f48326ba4a75c2e615f0c6