### PR TITLE
feat: add theme manager with toggle

### DIFF
--- a/src/ui/dashboard/Program.cs
+++ b/src/ui/dashboard/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddMudServices();
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddSignalR();
+builder.Services.AddScoped<Dashboard.Services.MudThemeManager>();
 
 builder.Services.Configure<GatewayOptions>(builder.Configuration.GetSection("GatewayUrls"));
 var useMocks = builder.Configuration.GetValue<bool>("UseMocks");

--- a/src/ui/dashboard/Services/MudThemeManager.cs
+++ b/src/ui/dashboard/Services/MudThemeManager.cs
@@ -1,0 +1,59 @@
+using Microsoft.JSInterop;
+using MudBlazor;
+
+namespace Dashboard.Services;
+
+public class MudThemeManager
+{
+    private readonly IJSRuntime _js;
+    private const string StorageKey = "aegis-theme";
+
+    public MudThemeManager(IJSRuntime js)
+    {
+        _js = js;
+        LightTheme = new MudTheme();
+        DarkTheme = new MudTheme
+        {
+            Palette = new PaletteDark
+            {
+                Primary = Colors.Blue.Lighten2,
+                Secondary = Colors.Pink.Accent2
+            }
+        };
+        CurrentTheme = DarkTheme;
+        IsDarkMode = true;
+    }
+
+    public MudTheme LightTheme { get; }
+    public MudTheme DarkTheme { get; }
+    public MudTheme CurrentTheme { get; private set; }
+    public bool IsDarkMode { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        var mode = await _js.InvokeAsync<string>("localStorage.getItem", StorageKey);
+        if (mode == "light")
+        {
+            IsDarkMode = false;
+            CurrentTheme = LightTheme;
+        }
+        else if (mode == "dark")
+        {
+            IsDarkMode = true;
+            CurrentTheme = DarkTheme;
+        }
+    }
+
+    public async Task ToggleThemeAsync()
+    {
+        IsDarkMode = !IsDarkMode;
+        CurrentTheme = IsDarkMode ? DarkTheme : LightTheme;
+        await _js.InvokeVoidAsync("localStorage.setItem", StorageKey, IsDarkMode ? "dark" : "light");
+    }
+
+    public void SetCustomTheme(MudTheme theme)
+    {
+        CurrentTheme = theme;
+    }
+}
+

--- a/src/ui/dashboard/Shared/MainLayout.razor
+++ b/src/ui/dashboard/Shared/MainLayout.razor
@@ -2,15 +2,18 @@
 @using MudBlazor
 @using Microsoft.Extensions.Configuration
 
-<MudThemeProvider IsDarkMode="true" />
+@inject MudThemeManager ThemeManager
+
+<MudThemeProvider Theme="@ThemeManager.CurrentTheme" IsDarkMode="@ThemeManager.IsDarkMode" />
 <MudDialogProvider />
 <MudSnackbarProvider />
 
 <div tabindex="0" @onkeydown="HandleKey">
     <MudLayout>
         <MudAppBar Color="Color.Primary">
-            Aegis Dashboard
+            <span class="neon-title">Aegis Dashboard</span>
             <MudSpacer />
+            <MudIconButton Icon="@(ThemeManager.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)" Color="Color.Inherit" OnClick="ToggleTheme" />
             <MudChip Color="Color.Error" Variant="Variant.Filled">ALPHA</MudChip>
         </MudAppBar>
         <MudDrawer Open="true" ClipMode="DrawerClipMode.Always" Variant="DrawerVariant.Mini">
@@ -31,6 +34,21 @@
     [Inject] IConfiguration Configuration { get; set; } = default!;
 
     private bool UseMocks => Configuration.GetValue<bool>("UseMocks");
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await ThemeManager.InitializeAsync();
+            StateHasChanged();
+        }
+    }
+
+    private async Task ToggleTheme()
+    {
+        await ThemeManager.ToggleThemeAsync();
+        StateHasChanged();
+    }
 
     private void HandleKey(KeyboardEventArgs e)
     {

--- a/src/ui/dashboard/wwwroot/css/app.css
+++ b/src/ui/dashboard/wwwroot/css/app.css
@@ -35,3 +35,15 @@
     font-weight: bold;
     z-index: 1000;
 }
+
+.neon-title {
+    font-weight: bold;
+    color: #39ff14;
+    text-shadow: 0 0 5px #39ff14, 0 0 10px #39ff14, 0 0 20px #39ff14, 0 0 40px #39ff14;
+    animation: neon-flicker 1.5s infinite alternate;
+}
+
+@keyframes neon-flicker {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.8; }
+}


### PR DESCRIPTION
## Summary
- replace static MudThemeProvider with injected MudThemeManager and add app bar theme toggle
- register theme manager service and persist choice in localStorage
- style dashboard title with neon animation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b170c182d083269c878d2d8a1c575d