### PR TITLE
Integrate summarizer service for AI insights

### DIFF
--- a/src/ui/dashboard/Models/SummarizerContracts.cs
+++ b/src/ui/dashboard/Models/SummarizerContracts.cs
@@ -1,0 +1,28 @@
+namespace Dashboard.Models;
+
+public sealed record FeatureEventLite(
+    DateTimeOffset Timestamp,
+    string ClientId,
+    string RouteKey,
+    int StatusCode,
+    bool SchemaError,
+    int WafHitCount,
+    double UaEntropy);
+
+public sealed record IncidentBundle(
+    string Environment,
+    string DetectorMode,
+    string DetectorReason,
+    IReadOnlyList<FeatureEventLite> RecentEvents,
+    IDictionary<string,double> Counters,
+    IDictionary<string,int> TopPaths,
+    string? Notes);
+
+public sealed record PolicyPatch(string Type, string Path, string Rule, IDictionary<string,string> Params);
+
+public sealed record SummaryResponse(
+    string Summary,
+    string ProbableCause,
+    PolicyPatch? SuggestedPolicyPatch,
+    double Confidence,
+    string[] NextSteps);

--- a/src/ui/dashboard/Options/GatewayOptions.cs
+++ b/src/ui/dashboard/Options/GatewayOptions.cs
@@ -5,4 +5,5 @@ public class GatewayOptions
     public string Metrics { get; set; } = "";
     public string Incidents { get; set; } = "";
     public string Control { get; set; } = "";
+    public string Summarizer { get; set; } = "";
 }

--- a/src/ui/dashboard/Pages/IncidentDetail.razor
+++ b/src/ui/dashboard/Pages/IncidentDetail.razor
@@ -1,6 +1,7 @@
 @page "/incidents/{id}"
 @inject IIncidentService IncidentService
 @inject IControlPlaneService ControlService
+@inject ISummarizerService SummarizerService
 @inject ISnackbar Snackbar
 
 <h3>Incident Detail</h3>
@@ -17,11 +18,27 @@ else
         <MudText>Status: @incident.Status</MudText>
         <MudButton Color="Color.Primary" OnClick="ApplyFix" Disabled="loading">Apply Fix</MudButton>
     </MudCard>
+
+    @if (summary is not null)
+    {
+        <MudCard Class="pa-4 mt-4">
+            <MudText Typo="Typo.h6">AI Insights</MudText>
+            <MudAlert Severity="Severity.Info">
+                <div>@summary.Summary</div>
+                @if (summary.SuggestedPolicyPatch is not null)
+                {
+                    <div>Patch: @summary.SuggestedPolicyPatch.Rule</div>
+                }
+                <div>Confidence: @summary.Confidence.ToString("P0")</div>
+            </MudAlert>
+        </MudCard>
+    }
 }
 
 @code {
     [Parameter] public string id { get; set; } = string.Empty;
     private Incident? incident;
+    private SummaryResponse? summary;
     private bool loading;
 
     protected override async Task OnInitializedAsync()
@@ -29,6 +46,15 @@ else
         try
         {
             incident = await IncidentService.GetIncidentAsync(id);
+            var bundle = new IncidentBundle(
+                "dev",
+                "UI",
+                incident.Title,
+                Array.Empty<FeatureEventLite>(),
+                new Dictionary<string,double>(),
+                new Dictionary<string,int>(),
+                null);
+            summary = await SummarizerService.SummarizeAsync(bundle);
         }
         catch (Exception ex)
         {

--- a/src/ui/dashboard/Program.cs
+++ b/src/ui/dashboard/Program.cs
@@ -21,6 +21,7 @@ if (useMocks)
     builder.Services.AddScoped<IMetricsService, MockMetricsService>();
     builder.Services.AddScoped<IIncidentService, MockIncidentService>();
     builder.Services.AddScoped<IControlPlaneService, MockControlPlaneService>();
+    builder.Services.AddScoped<ISummarizerService, MockSummarizerService>();
 }
 else
 {
@@ -39,9 +40,15 @@ else
         var opts = sp.GetRequiredService<IOptions<GatewayOptions>>().Value;
         client.BaseAddress = new Uri(opts.Control);
     });
+    builder.Services.AddHttpClient<RealSummarizerService>((sp, client) =>
+    {
+        var opts = sp.GetRequiredService<IOptions<GatewayOptions>>().Value;
+        client.BaseAddress = new Uri(opts.Summarizer);
+    });
     builder.Services.AddScoped<IMetricsService, RealMetricsService>();
     builder.Services.AddScoped<IIncidentService, RealIncidentService>();
     builder.Services.AddScoped<IControlPlaneService, RealControlPlaneService>();
+    builder.Services.AddScoped<ISummarizerService, RealSummarizerService>();
 }
 
 var app = builder.Build();

--- a/src/ui/dashboard/Services/ISummarizerService.cs
+++ b/src/ui/dashboard/Services/ISummarizerService.cs
@@ -1,0 +1,8 @@
+using Dashboard.Models;
+
+namespace Dashboard.Services;
+
+public interface ISummarizerService
+{
+    Task<SummaryResponse?> SummarizeAsync(IncidentBundle bundle, CancellationToken ct = default);
+}

--- a/src/ui/dashboard/Services/Mock/MockSummarizerService.cs
+++ b/src/ui/dashboard/Services/Mock/MockSummarizerService.cs
@@ -1,0 +1,13 @@
+using Dashboard.Models;
+
+namespace Dashboard.Services.Mock;
+
+public class MockSummarizerService : ISummarizerService
+{
+    public Task<SummaryResponse?> SummarizeAsync(IncidentBundle bundle, CancellationToken ct = default)
+    {
+        var patch = new PolicyPatch("mock", "/", "allow", new Dictionary<string,string>());
+        var summary = new SummaryResponse("Mock summary", "Mock cause", patch, 1.0, Array.Empty<string>());
+        return Task.FromResult<SummaryResponse?>(summary);
+    }
+}

--- a/src/ui/dashboard/Services/Real/RealSummarizerService.cs
+++ b/src/ui/dashboard/Services/Real/RealSummarizerService.cs
@@ -1,0 +1,21 @@
+using System.Net.Http.Json;
+using Dashboard.Models;
+
+namespace Dashboard.Services.Real;
+
+public class RealSummarizerService : ISummarizerService
+{
+    private readonly HttpClient _http;
+
+    public RealSummarizerService(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<SummaryResponse?> SummarizeAsync(IncidentBundle bundle, CancellationToken ct = default)
+    {
+        var res = await _http.PostAsJsonAsync("/ai/summarize", bundle, ct);
+        res.EnsureSuccessStatusCode();
+        return await res.Content.ReadFromJsonAsync<SummaryResponse>(cancellationToken: ct);
+    }
+}

--- a/src/ui/dashboard/appsettings.json
+++ b/src/ui/dashboard/appsettings.json
@@ -3,6 +3,7 @@
   "GatewayUrls": {
     "Metrics": "https://localhost:5001",
     "Incidents": "https://localhost:5001",
-    "Control": "https://localhost:5001"
+    "Control": "https://localhost:5001",
+    "Summarizer": "http://localhost:5290"
   }
 }


### PR DESCRIPTION
## Summary
- register SummarizerService client
- invoke AI summarizer on incident details
- show AI insights panel with policy patch suggestion and confidence

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b170c33de88326a43f20ca3ac485cb