### PR TITLE
feat: integrate monaco editor for policies

### DIFF
--- a/src/ui/dashboard/Dashboard.csproj
+++ b/src/ui/dashboard/Dashboard.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <PackageReference Include="MudBlazor" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    <PackageReference Include="BlazorMonaco" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/ui/dashboard/Pages/Policies.razor
+++ b/src/ui/dashboard/Pages/Policies.razor
@@ -3,13 +3,20 @@
 @inject IControlPlaneService ControlService
 @inject ISnackbar Snackbar
 
-<MudTextField @bind-Value="policy" Label="Policy JSON" Lines="15" Class="ma-2" />
+<MonacoEditor @ref="editor" @bind-Value="policy" Options="editorOptions" Height="300px" Class="ma-2" />
 <MudButton OnClick="Validate" Color="Color.Primary">Validate</MudButton>
 <MudButton OnClick="Format" Color="Color.Secondary">Format</MudButton>
 <MudButton OnClick="Save" Color="Color.Success">Save</MudButton>
+<MudButton OnClick="SuggestPatch" Color="Color.Info">Suggerisci patch</MudButton>
 
 @code {
+    private MonacoEditor? editor;
     private string policy = "{}";
+    private StandaloneEditorConstructionOptions editorOptions = new()
+    {
+        Language = "json",
+        AutomaticLayout = true
+    };
 
     protected override async Task OnInitializedAsync()
     {
@@ -36,12 +43,15 @@
         }
     }
 
-    private void Format()
+    private async Task Format()
     {
         try
         {
-            using var doc = JsonDocument.Parse(policy);
-            policy = JsonSerializer.Serialize(doc, new JsonSerializerOptions { WriteIndented = true });
+            if (editor is not null)
+            {
+                await editor.Trigger("keyboard", "editor.action.formatDocument", null);
+                policy = await editor.GetValue();
+            }
         }
         catch
         {
@@ -53,8 +63,24 @@
     {
         try
         {
+            if (editor is not null)
+                policy = await editor.GetValue();
             await ControlService.SavePolicyAsync(policy);
             Snackbar.Add("Policy saved", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Warning);
+        }
+    }
+
+    private async Task SuggestPatch()
+    {
+        try
+        {
+            if (editor is not null)
+                policy = await editor.GetValue();
+            policy = await ControlService.SuggestPolicyPatchAsync(policy);
         }
         catch (Exception ex)
         {

--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -18,5 +18,6 @@
 
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/BlazorMonaco/js/monaco.js"></script>
 </body>
 </html>

--- a/src/ui/dashboard/Services/IControlPlaneService.cs
+++ b/src/ui/dashboard/Services/IControlPlaneService.cs
@@ -5,4 +5,5 @@ public interface IControlPlaneService
     Task ApplyFixAsync(string incidentId);
     Task<string> LoadPolicyAsync();
     Task SavePolicyAsync(string policyJson);
+    Task<string> SuggestPolicyPatchAsync(string policyJson);
 }

--- a/src/ui/dashboard/Services/Mock/MockControlPlaneService.cs
+++ b/src/ui/dashboard/Services/Mock/MockControlPlaneService.cs
@@ -20,4 +20,9 @@ public class MockControlPlaneService : IControlPlaneService
         _policy = policyJson;
         return Task.CompletedTask;
     }
+
+    public Task<string> SuggestPolicyPatchAsync(string policyJson)
+    {
+        return Task.FromResult(policyJson);
+    }
 }

--- a/src/ui/dashboard/Services/Real/RealControlPlaneService.cs
+++ b/src/ui/dashboard/Services/Real/RealControlPlaneService.cs
@@ -13,4 +13,7 @@ public class RealControlPlaneService : IControlPlaneService
 
     public Task SavePolicyAsync(string policyJson)
         => throw new NotImplementedException("Coming soon");
+
+    public Task<string> SuggestPolicyPatchAsync(string policyJson)
+        => throw new NotImplementedException("Coming soon");
 }

--- a/src/ui/dashboard/_Imports.razor
+++ b/src/ui/dashboard/_Imports.razor
@@ -4,5 +4,7 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using MudBlazor
+@using BlazorMonaco
+@using BlazorMonaco.Editor
 @using global::Dashboard.Models
 @using global::Dashboard.Services


### PR DESCRIPTION
## Summary
- replace policy text field with Monaco editor for syntax highlighting and formatting
- allow requesting policy patch suggestions via control plane service
- reference BlazorMonaco package and wire up supporting scripts

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b170c60e7483268c8ee3f36e3560dd