### PR TITLE
Add command palette with fuzzy search

### DIFF
--- a/src/ui/dashboard/Shared/MainLayout.razor
+++ b/src/ui/dashboard/Shared/MainLayout.razor
@@ -6,7 +6,7 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 
-<div tabindex="0" @onkeydown="HandleKey">
+<div tabindex="0" @onkeydown="HandleKey" @onkeydown:preventDefault="true" @onkeydown:stopPropagation="true">
     <MudLayout>
         <MudAppBar Color="Color.Primary">
             Aegis Dashboard
@@ -29,11 +29,18 @@
 @code {
     [Inject] NavigationManager Nav { get; set; } = default!;
     [Inject] IConfiguration Configuration { get; set; } = default!;
+    [Inject] IDialogService Dialog { get; set; } = default!;
 
     private bool UseMocks => Configuration.GetValue<bool>("UseMocks");
 
     private void HandleKey(KeyboardEventArgs e)
     {
+        if ((e.CtrlKey || e.MetaKey) && e.Key.Equals("k", StringComparison.OrdinalIgnoreCase))
+        {
+            OpenCommandPalette();
+            return;
+        }
+
         switch (e.Key.ToLowerInvariant())
         {
             case "d":
@@ -46,5 +53,16 @@
                 Nav.NavigateTo("/policies");
                 break;
         }
+    }
+
+    private void OpenCommandPalette()
+    {
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            DisableBackdropClick = true
+        };
+
+        Dialog.Show<SearchDialog>("Command Palette", options);
     }
 }

--- a/src/ui/dashboard/Shared/SearchDialog.razor
+++ b/src/ui/dashboard/Shared/SearchDialog.razor
@@ -1,0 +1,76 @@
+@inject NavigationManager Nav
+@inject IIncidentService IncidentService
+@CascadingParameter MudDialogInstance MudDialog { get; set; } = default!
+
+<MudDialogContent>
+    <MudTextField @bind-Value="searchText" Placeholder="Search..." Immediate="true" AutoFocus="true" OnKeyDown="HandleInputKey" />
+    <MudList Dense="true">
+        @foreach (var item in FilteredItems)
+        {
+            <MudListItem @onclick="() => Select(item)">@item.Title</MudListItem>
+        }
+    </MudList>
+</MudDialogContent>
+
+@code {
+    private readonly List<SearchItem> items = new();
+    private string searchText = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        items.Add(new("Apri dashboard", () => Nav.NavigateTo("/")));
+        items.Add(new("Apri incidenti", () => Nav.NavigateTo("/incidents")));
+        items.Add(new("Apri policy", () => Nav.NavigateTo("/policies")));
+        items.Add(new("Nuovo incidente", () => Nav.NavigateTo("/incidents/new")));
+
+        try
+        {
+            var incidents = await IncidentService.GetIncidentsAsync();
+            foreach (var incident in incidents)
+            {
+                var local = incident;
+                items.Add(new(local.Title, () => Nav.NavigateTo($"/incidents/{local.Id}")));
+            }
+        }
+        catch
+        {
+            // ignore fetching errors in quick search
+        }
+    }
+
+    private IEnumerable<SearchItem> FilteredItems => items.Where(i => FuzzyMatch(i.Title, searchText)).Take(10);
+
+    private bool FuzzyMatch(string source, string pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+            return true;
+        source = source.ToLowerInvariant();
+        pattern = pattern.ToLowerInvariant();
+        int s = 0, p = 0;
+        while (s < source.Length && p < pattern.Length)
+        {
+            if (source[s] == pattern[p])
+                p++;
+            s++;
+        }
+        return p == pattern.Length;
+    }
+
+    private void HandleInputKey(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            var item = FilteredItems.FirstOrDefault();
+            if (item != null)
+                Select(item);
+        }
+    }
+
+    private void Select(SearchItem item)
+    {
+        MudDialog.Close(DialogResult.Ok(true));
+        item.Action.Invoke();
+    }
+
+    private record SearchItem(string Title, Action Action);
+}


### PR DESCRIPTION
## Summary
- intercept Ctrl+K in MainLayout to open a command palette dialog
- implement fuzzy search dialog listing pages, incidents, and common actions
- route selected search results through existing navigation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b170c8adb88326b555b2155fd109c1