### PR TITLE
feat(ui): add severity filters and tooltip previews

### DIFF
--- a/src/ui/dashboard/Models/Incident.cs
+++ b/src/ui/dashboard/Models/Incident.cs
@@ -5,6 +5,7 @@ public class Incident
     public string Id { get; set; } = Guid.NewGuid().ToString();
     public string Title { get; set; } = "";
     public string Status { get; set; } = "";
+    public string Severity { get; set; } = "";
     public string Summary { get; set; } = "";
     public DateTime CreatedAt { get; set; }
 }

--- a/src/ui/dashboard/Pages/Incidents.razor
+++ b/src/ui/dashboard/Pages/Incidents.razor
@@ -1,23 +1,65 @@
 @page "/incidents"
+@using System.Linq
 @inject IIncidentService IncidentService
 @inject NavigationManager Nav
 @inject ISnackbar Snackbar
 
-<MudTable Items="incidents" Hover="true" Dense="true" RowClick="OnRowClick">
+<MudStack Direction="Row" Spacing="2" Class="mb-4">
+    <MudTextField @bind-Value="searchString" Placeholder="Search" Adornment="Start" AdornmentIcon="@Icons.Material.Filled.Search" />
+    <MudSelect T="string" @bind-Value="statusFilter" Placeholder="Status">
+        <MudSelectItem Value="">All</MudSelectItem>
+        @foreach (var status in StatusOptions)
+        {
+            <MudSelectItem Value="@status">@status</MudSelectItem>
+        }
+    </MudSelect>
+    <MudSelect T="string" @bind-Value="severityFilter" Placeholder="Severity">
+        <MudSelectItem Value="">All</MudSelectItem>
+        @foreach (var sev in SeverityOptions)
+        {
+            <MudSelectItem Value="@sev">@sev</MudSelectItem>
+        }
+    </MudSelect>
+</MudStack>
+
+<MudTable Items="FilteredIncidents" Hover="true" Dense="true" RowClick="OnRowClick">
     <HeaderContent>
         <MudTh>Id</MudTh>
         <MudTh>Title</MudTh>
         <MudTh>Status</MudTh>
+        <MudTh>Severity</MudTh>
     </HeaderContent>
     <RowTemplate>
-        <MudTd DataLabel="Id">@context.Id</MudTd>
-        <MudTd DataLabel="Title">@context.Title</MudTd>
-        <MudTd DataLabel="Status">@context.Status</MudTd>
+        <MudTd DataLabel="Id">
+            <MudTooltip Text="@context.Summary">@context.Id</MudTooltip>
+        </MudTd>
+        <MudTd DataLabel="Title">
+            <MudTooltip Text="@context.Summary">@context.Title</MudTooltip>
+        </MudTd>
+        <MudTd DataLabel="Status">
+            <MudTooltip Text="@context.Summary">@context.Status</MudTooltip>
+        </MudTd>
+        <MudTd DataLabel="Severity">
+            <MudTooltip Text="@context.Summary">
+                <MudChip Color="@GetSeverityColor(context.Severity)" Variant="Variant.Filled">@context.Severity</MudChip>
+            </MudTooltip>
+        </MudTd>
     </RowTemplate>
 </MudTable>
 
 @code {
     private IReadOnlyList<Incident> incidents = Array.Empty<Incident>();
+    private string searchString = string.Empty;
+    private string statusFilter = string.Empty;
+    private string severityFilter = string.Empty;
+
+    private IEnumerable<Incident> FilteredIncidents => incidents
+        .Where(i => string.IsNullOrWhiteSpace(searchString) || i.Title.Contains(searchString, StringComparison.OrdinalIgnoreCase))
+        .Where(i => string.IsNullOrWhiteSpace(statusFilter) || i.Status == statusFilter)
+        .Where(i => string.IsNullOrWhiteSpace(severityFilter) || i.Severity == severityFilter);
+
+    private IEnumerable<string> StatusOptions => incidents.Select(i => i.Status).Distinct();
+    private IEnumerable<string> SeverityOptions => incidents.Select(i => i.Severity).Distinct();
 
     protected override async Task OnInitializedAsync()
     {
@@ -30,6 +72,15 @@
             Snackbar.Add(ex.Message, Severity.Warning);
         }
     }
+
+    private Color GetSeverityColor(string severity) => severity?.ToLowerInvariant() switch
+    {
+        "critical" => Color.Error,
+        "high" => Color.Warning,
+        "medium" => Color.Info,
+        "low" => Color.Success,
+        _ => Color.Default
+    };
 
     private void OnRowClick(TableRowClickEventArgs<Incident> e)
         => Nav.NavigateTo($"/incidents/{e.Item.Id}");

--- a/src/ui/dashboard/Services/Mock/MockIncidentService.cs
+++ b/src/ui/dashboard/Services/Mock/MockIncidentService.cs
@@ -11,6 +11,7 @@ public class MockIncidentService : IIncidentService
             Id = "1",
             Title = "Unauthorized Access",
             Status = "Open",
+            Severity = "Critical",
             Summary = "AI: suspicious login from unknown device detected",
             CreatedAt = DateTime.UtcNow.AddMinutes(-30)
         },
@@ -19,6 +20,7 @@ public class MockIncidentService : IIncidentService
             Id = "2",
             Title = "Malware Detected",
             Status = "Investigating",
+            Severity = "High",
             Summary = "AI: malware signature matched (Trojan.X)",
             CreatedAt = DateTime.UtcNow.AddHours(-2)
         },
@@ -27,6 +29,7 @@ public class MockIncidentService : IIncidentService
             Id = "3",
             Title = "Data Exfiltration",
             Status = "Mitigated",
+            Severity = "Medium",
             Summary = "AI: unusual outbound traffic blocked",
             CreatedAt = DateTime.UtcNow.AddHours(-4)
         }


### PR DESCRIPTION
## Summary
- add severity property to incident model and mock data
- add search, status and severity filters to incidents table
- color-code severity chips and show summary tooltip on hover

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b170cae49083269ad6a8b3413f4f86