### PR TITLE
Add network map page using Blazor diagrams

### DIFF
--- a/src/ui/dashboard/Dashboard.csproj
+++ b/src/ui/dashboard/Dashboard.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <PackageReference Include="MudBlazor" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
+    <PackageReference Include="Blazor.Diagrams" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/src/ui/dashboard/Models/NetworkDto.cs
+++ b/src/ui/dashboard/Models/NetworkDto.cs
@@ -1,0 +1,5 @@
+namespace Dashboard.Models;
+
+public record NetworkNodeDto(string Id, string Label, int Requests, double Latency);
+public record NetworkLinkDto(string SourceId, string TargetId, int Requests, double Latency);
+public record NetworkDto(IReadOnlyList<NetworkNodeDto> Nodes, IReadOnlyList<NetworkLinkDto> Links);

--- a/src/ui/dashboard/Pages/Network.razor
+++ b/src/ui/dashboard/Pages/Network.razor
@@ -1,0 +1,33 @@
+@page "/network"
+@inject INetworkService NetworkService
+
+<BlazorDiagram Diagram="@_diagram" />
+
+@code {
+    private Diagram _diagram = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var data = await NetworkService.GetNetworkAsync();
+        var index = 0;
+        foreach (var nodeDto in data.Nodes)
+        {
+            var node = new NodeModel(new Point(150 * index, 100))
+            {
+                Id = nodeDto.Id,
+                Title = $"{nodeDto.Label}\n{nodeDto.Requests} req/s\n{nodeDto.Latency} ms"
+            };
+            _diagram.Nodes.Add(node);
+            index++;
+        }
+
+        foreach (var linkDto in data.Links)
+        {
+            var source = _diagram.Nodes.OfType<NodeModel>().First(n => n.Id == linkDto.SourceId);
+            var target = _diagram.Nodes.OfType<NodeModel>().First(n => n.Id == linkDto.TargetId);
+            var link = new LinkModel(source, target);
+            link.Labels.Add(new LinkLabelModel($"{linkDto.Requests} req/s / {linkDto.Latency} ms"));
+            _diagram.Links.Add(link);
+        }
+    }
+}

--- a/src/ui/dashboard/Program.cs
+++ b/src/ui/dashboard/Program.cs
@@ -21,6 +21,7 @@ if (useMocks)
     builder.Services.AddScoped<IMetricsService, MockMetricsService>();
     builder.Services.AddScoped<IIncidentService, MockIncidentService>();
     builder.Services.AddScoped<IControlPlaneService, MockControlPlaneService>();
+    builder.Services.AddScoped<INetworkService, MockNetworkService>();
 }
 else
 {
@@ -39,9 +40,15 @@ else
         var opts = sp.GetRequiredService<IOptions<GatewayOptions>>().Value;
         client.BaseAddress = new Uri(opts.Control);
     });
+    builder.Services.AddHttpClient<RealNetworkService>((sp, client) =>
+    {
+        var opts = sp.GetRequiredService<IOptions<GatewayOptions>>().Value;
+        client.BaseAddress = new Uri(opts.Metrics);
+    });
     builder.Services.AddScoped<IMetricsService, RealMetricsService>();
     builder.Services.AddScoped<IIncidentService, RealIncidentService>();
     builder.Services.AddScoped<IControlPlaneService, RealControlPlaneService>();
+    builder.Services.AddScoped<INetworkService, RealNetworkService>();
 }
 
 var app = builder.Build();

--- a/src/ui/dashboard/Services/INetworkService.cs
+++ b/src/ui/dashboard/Services/INetworkService.cs
@@ -1,0 +1,8 @@
+using Dashboard.Models;
+
+namespace Dashboard.Services;
+
+public interface INetworkService
+{
+    Task<NetworkDto> GetNetworkAsync(CancellationToken token = default);
+}

--- a/src/ui/dashboard/Services/Mock/MockNetworkService.cs
+++ b/src/ui/dashboard/Services/Mock/MockNetworkService.cs
@@ -1,0 +1,22 @@
+using Dashboard.Models;
+
+namespace Dashboard.Services.Mock;
+
+public class MockNetworkService : INetworkService
+{
+    public Task<NetworkDto> GetNetworkAsync(CancellationToken token = default)
+    {
+        var nodes = new[]
+        {
+            new NetworkNodeDto("gateway", "Gateway", 200, 5),
+            new NetworkNodeDto("service-a", "Service A", 120, 30),
+            new NetworkNodeDto("service-b", "Service B", 80, 45)
+        };
+        var links = new[]
+        {
+            new NetworkLinkDto("gateway", "service-a", 120, 30),
+            new NetworkLinkDto("gateway", "service-b", 80, 45)
+        };
+        return Task.FromResult(new NetworkDto(nodes, links));
+    }
+}

--- a/src/ui/dashboard/Services/Real/RealNetworkService.cs
+++ b/src/ui/dashboard/Services/Real/RealNetworkService.cs
@@ -1,0 +1,13 @@
+using Dashboard.Models;
+
+namespace Dashboard.Services.Real;
+
+public class RealNetworkService : INetworkService
+{
+    private readonly HttpClient _http;
+    public RealNetworkService(HttpClient http) => _http = http;
+
+    public async Task<NetworkDto> GetNetworkAsync(CancellationToken token = default)
+        => await _http.GetFromJsonAsync<NetworkDto>("network", token)
+            ?? new NetworkDto(Array.Empty<NetworkNodeDto>(), Array.Empty<NetworkLinkDto>());
+}

--- a/src/ui/dashboard/Shared/NavMenu.razor
+++ b/src/ui/dashboard/Shared/NavMenu.razor
@@ -3,4 +3,8 @@
     <MudNavLink Href="/" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All" AccessKey="d">Dashboard</MudNavLink>
     <MudNavLink Href="/incidents" Icon="@Icons.Material.Filled.List" AccessKey="i">Incidents</MudNavLink>
     <MudNavLink Href="/policies" Icon="@Icons.Material.Filled.Policy" AccessKey="p">Policies</MudNavLink>
+    <MudNavLink Href="/network" AccessKey="n">
+        <MudIcon Icon="@Icons.Material.Filled.DeviceHub" Class="network-icon" />
+        <span class="mud-nav-link-text">Network Map</span>
+    </MudNavLink>
 </MudNavMenu>

--- a/src/ui/dashboard/_Imports.razor
+++ b/src/ui/dashboard/_Imports.razor
@@ -4,5 +4,7 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using MudBlazor
+@using Blazor.Diagrams
+@using Blazor.Diagrams.Core.Models
 @using global::Dashboard.Models
 @using global::Dashboard.Services

--- a/src/ui/dashboard/wwwroot/css/app.css
+++ b/src/ui/dashboard/wwwroot/css/app.css
@@ -35,3 +35,14 @@
     font-weight: bold;
     z-index: 1000;
 }
+
+@keyframes pulse-icon {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}
+
+.network-icon {
+    display: inline-block;
+    animation: pulse-icon 2s infinite;
+}


### PR DESCRIPTION
## Summary
- add Network page rendering gateway nodes and links with Blazor.Diagrams
- stream mock or real network data through new network services and model
- link new Network Map page in nav menu with animated icon

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b170cd5fe88326bc86cc1e6c8796b8