### PR TITLE
feat: make dashboard widgets draggable

### DIFF
--- a/src/ui/dashboard/Pages/Dashboard.razor
+++ b/src/ui/dashboard/Pages/Dashboard.razor
@@ -2,50 +2,38 @@
 @inject IMetricsService MetricsService
 @inject ISnackbar Snackbar
 
-<MudGrid Class="pa-4">
-    <MudItem xs="12" sm="6" md="3">
-        <MudCard Class="wow-card pa-4">
-            <MudCardContent Class="text-center">
-                <MudIcon Icon="@Icons.Material.Filled.Speed" Size="Size.Large" />
-                <MudText Typo="Typo.subtitle1">Requests/s</MudText>
-                <MudText Typo="Typo.h4">@rps.ToString("F1")</MudText>
-            </MudCardContent>
-        </MudCard>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="3">
-        <MudCard Class="wow-card pa-4">
-            <MudCardContent Class="text-center">
-                <MudIcon Icon="@Icons.Material.Filled.DeviceUnknown" Size="Size.Large" />
-                <MudText Typo="Typo.subtitle1">UA Entropy</MudText>
-                <MudText Typo="Typo.h4">@uaEntropy.ToString("F2")</MudText>
-            </MudCardContent>
-        </MudCard>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="3">
-        <MudCard Class="wow-card pa-4">
-            <MudCardContent Class="text-center">
-                <MudIcon Icon="@Icons.Material.Filled.Rule" Size="Size.Large" />
-                <MudText Typo="Typo.subtitle1">Schema Errors</MudText>
-                <MudText Typo="Typo.h4">@schemaErrors</MudText>
-            </MudCardContent>
-        </MudCard>
-    </MudItem>
-    <MudItem xs="12" sm="6" md="3">
-        <MudCard Class="wow-card pa-4">
-            <MudCardContent Class="text-center">
-                <MudIcon Icon="@Icons.Material.Filled.Shield" Size="Size.Large" />
-                <MudText Typo="Typo.subtitle1">WAF Blocks</MudText>
-                <MudText Typo="Typo.h4">@wafBlocks</MudText>
-            </MudCardContent>
-        </MudCard>
-    </MudItem>
-</MudGrid>
+<MudPaper Class="pa-4">
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ResetLayout">Reset layout</MudButton>
+    <div class="grid-stack mt-4">
+        <div class="grid-stack-item" id="rps" gs-x="0" gs-y="0" gs-w="3" gs-h="2">
+            <div class="grid-stack-item-content">
+                <MetricCard Icon="@Icons.Material.Filled.Speed" Title="Requests/s" Value="@rps.ToString("F1")" />
+            </div>
+        </div>
+        <div class="grid-stack-item" id="ua" gs-x="3" gs-y="0" gs-w="3" gs-h="2">
+            <div class="grid-stack-item-content">
+                <MetricCard Icon="@Icons.Material.Filled.DeviceUnknown" Title="UA Entropy" Value="@uaEntropy.ToString("F2")" />
+            </div>
+        </div>
+        <div class="grid-stack-item" id="schema" gs-x="6" gs-y="0" gs-w="3" gs-h="2">
+            <div class="grid-stack-item-content">
+                <MetricCard Icon="@Icons.Material.Filled.Rule" Title="Schema Errors" Value="@schemaErrors.ToString()" />
+            </div>
+        </div>
+        <div class="grid-stack-item" id="waf" gs-x="9" gs-y="0" gs-w="3" gs-h="2">
+            <div class="grid-stack-item-content">
+                <MetricCard Icon="@Icons.Material.Filled.Shield" Title="WAF Blocks" Value="@wafBlocks.ToString()" />
+            </div>
+        </div>
+    </div>
+</MudPaper>
 
 @code {
     private double rps;
     private double uaEntropy;
     private int schemaErrors;
     private int wafBlocks;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
     private CancellationTokenSource? cts;
 
     protected override async Task OnInitializedAsync()
@@ -69,6 +57,19 @@
         wafBlocks = m.WafBlocks;
         InvokeAsync(StateHasChanged);
         return Task.CompletedTask;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("dashboardLayout.init");
+        }
+    }
+
+    private async Task ResetLayout()
+    {
+        await JS.InvokeVoidAsync("dashboardLayout.reset");
     }
 
     public void Dispose()

--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -10,6 +10,7 @@
     <base href="~/" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/gridstack@8.4.0/dist/gridstack.min.css" rel="stylesheet" />
 </head>
 <body>
     <app>
@@ -18,5 +19,7 @@
 
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gridstack@8.4.0/dist/gridstack-h5.js"></script>
+    <script src="js/layout.js"></script>
 </body>
 </html>

--- a/src/ui/dashboard/Shared/MetricCard.razor
+++ b/src/ui/dashboard/Shared/MetricCard.razor
@@ -1,0 +1,13 @@
+<MudCard Class="wow-card pa-4">
+    <MudCardContent Class="text-center">
+        <MudIcon Icon="@Icon" Size="Size.Large" />
+        <MudText Typo="Typo.subtitle1">@Title</MudText>
+        <MudText Typo="Typo.h4">@Value</MudText>
+    </MudCardContent>
+</MudCard>
+
+@code {
+    [Parameter] public string Icon { get; set; } = string.Empty;
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string Value { get; set; } = string.Empty;
+}

--- a/src/ui/dashboard/_Imports.razor
+++ b/src/ui/dashboard/_Imports.razor
@@ -6,3 +6,5 @@
 @using MudBlazor
 @using global::Dashboard.Models
 @using global::Dashboard.Services
+@using Dashboard.Shared
+@using Microsoft.JSInterop

--- a/src/ui/dashboard/wwwroot/js/layout.js
+++ b/src/ui/dashboard/wwwroot/js/layout.js
@@ -1,0 +1,19 @@
+window.dashboardLayout = {
+    init: function () {
+        const grid = GridStack.init({
+            float: true
+        });
+        const saved = localStorage.getItem('dashboardLayout');
+        if (saved) {
+            grid.load(JSON.parse(saved));
+        }
+        grid.on('change', function () {
+            const layout = grid.save();
+            localStorage.setItem('dashboardLayout', JSON.stringify(layout));
+        });
+    },
+    reset: function () {
+        localStorage.removeItem('dashboardLayout');
+        location.reload();
+    }
+};


### PR DESCRIPTION
## Summary
- integrate GridStack.js to allow dragging and rearranging dashboard metrics
- persist widget positions in localStorage and provide layout reset button

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b170cf9e648326ae9b1b22765a717d