### PR TITLE
feat: refine dashboard style and theme toggle

### DIFF
--- a/src/ui/dashboard/Shared/MainLayout.razor
+++ b/src/ui/dashboard/Shared/MainLayout.razor
@@ -11,7 +11,7 @@
 <div tabindex="0" @onkeydown="HandleKey">
     <MudLayout>
         <MudAppBar Color="Color.Primary">
-            <span class="neon-title">Aegis Dashboard</span>
+            <span class="cursive-title">Aegis Dashboard</span>
             <MudSpacer />
             <MudIconButton Icon="@(ThemeManager.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)" Color="Color.Inherit" OnClick="ToggleTheme" />
             <MudChip Color="Color.Error" Variant="Variant.Filled">ALPHA</MudChip>
@@ -19,7 +19,7 @@
         <MudDrawer Open="true" ClipMode="DrawerClipMode.Always" Variant="DrawerVariant.Mini">
             <NavMenu />
         </MudDrawer>
-        <MudMainContent Class="wow-bg">
+        <MudMainContent Class="app-background">
             @Body
         </MudMainContent>
     </MudLayout>

--- a/src/ui/dashboard/wwwroot/css/app.css
+++ b/src/ui/dashboard/wwwroot/css/app.css
@@ -1,7 +1,12 @@
+
+/* Use theme colors so the card adapts to light and dark modes */
 .wow-card {
-    background: linear-gradient(135deg, #1e88e5, #42a5f5, #5e35b1);
+    background: linear-gradient(135deg,
+            var(--mud-palette-primary),
+            var(--mud-palette-secondary),
+            var(--mud-palette-info));
     background-size: 300% 300%;
-    color: white;
+    color: var(--mud-palette-text-primary);
     transition: transform 0.3s, box-shadow 0.3s;
     box-shadow: 0 4px 15px rgba(0,0,0,0.2);
     animation: gradientShift 6s ease infinite;
@@ -12,8 +17,11 @@
     box-shadow: 0 8px 25px rgba(0,0,0,0.4);
 }
 
-.wow-bg {
-    background: radial-gradient(circle at top left, #0d47a1, #1b1b1b);
+
+/* Background that responds to the current theme */
+.app-background {
+    background-color: var(--mud-palette-background);
+    color: var(--mud-palette-text-primary);
     min-height: 100vh;
 }
 
@@ -36,14 +44,11 @@
     z-index: 1000;
 }
 
-.neon-title {
-    font-weight: bold;
-    color: #39ff14;
-    text-shadow: 0 0 5px #39ff14, 0 0 10px #39ff14, 0 0 20px #39ff14, 0 0 40px #39ff14;
-    animation: neon-flicker 1.5s infinite alternate;
+
+/* Elegant cursive title without flickering */
+.cursive-title {
+    font-family: "Brush Script MT", cursive;
+    font-style: italic;
+    color: var(--mud-palette-primary);
 }
 
-@keyframes neon-flicker {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.8; }
-}


### PR DESCRIPTION
## Summary
- remove flickering neon effect and switch to a cursive title
- make dashboard background and cards theme-aware so the theme toggle affects the whole app

## Testing
- `dotnet test` (fail: command not found)
- `apt-get update` (fail: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68b17374936083268fdad2b2cda72e87