### PR TITLE
feat(metrics): add configurable grid layout

### DIFF
--- a/src/ui/dashboard/Pages/Metrics.razor
+++ b/src/ui/dashboard/Pages/Metrics.razor
@@ -1,31 +1,37 @@
 @page "/metrics"
 @inject IMetricsService MetricsService
 @inject ISnackbar Snackbar
+@inject IJSRuntime JS
 
-<MudGrid Class="pa-4">
-    <MudItem xs="12" sm="6" md="3">
-        <MudChart ChartType="ChartType.Line"
-                  XAxisLabels="@labels.ToArray()"
-                  Series="@new[] { new ChartSeries { Name = "Requests/s", Data = rpsSamples.ToArray() } }" />
-    </MudItem>
-    <MudItem xs="12" sm="6" md="3">
-        <MudChart ChartType="ChartType.Line"
-                  XAxisLabels="@labels.ToArray()"
-                  Series="@new[] { new ChartSeries { Name = "UA Entropy", Data = uaEntropySamples.ToArray() } }" />
-    </MudItem>
-    <MudItem xs="12" sm="6" md="3">
-        <MudChart ChartType="ChartType.Line"
-                  XAxisLabels="@labels.ToArray()"
-                  Series="@new[] { new ChartSeries { Name = "Schema Errors", Data = schemaErrorSamples.ToArray() } }" />
-    </MudItem>
-    <MudItem xs="12" sm="6" md="3">
-        <MudChart ChartType="ChartType.Line"
-                  XAxisLabels="@labels.ToArray()"
-                  Series="@new[] { new ChartSeries { Name = "WAF Blocks", Data = wafBlockSamples.ToArray() } }" />
-    </MudItem>
-</MudGrid>
+<MudStack Class="pa-4" Spacing="2">
+    <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" OnClick="ResetLayout">Reset layout</MudButton>
+    <div class="grid-stack">
+        <MetricBlock Id="rps" X="0" Y="0" Width="3" Height="2">
+            <MudChart ChartType="ChartType.Line"
+                      XAxisLabels="@labels.ToArray()"
+                      Series="@new[] { new ChartSeries { Name = "Requests/s", Data = rpsSamples.ToArray() } }" />
+        </MetricBlock>
+        <MetricBlock Id="ua" X="3" Y="0" Width="3" Height="2">
+            <MudChart ChartType="ChartType.Line"
+                      XAxisLabels="@labels.ToArray()"
+                      Series="@new[] { new ChartSeries { Name = "UA Entropy", Data = uaEntropySamples.ToArray() } }" />
+        </MetricBlock>
+        <MetricBlock Id="schema" X="6" Y="0" Width="3" Height="2">
+            <MudChart ChartType="ChartType.Line"
+                      XAxisLabels="@labels.ToArray()"
+                      Series="@new[] { new ChartSeries { Name = "Schema Errors", Data = schemaErrorSamples.ToArray() } }" />
+        </MetricBlock>
+        <MetricBlock Id="waf" X="9" Y="0" Width="3" Height="2">
+            <MudChart ChartType="ChartType.Line"
+                      XAxisLabels="@labels.ToArray()"
+                      Series="@new[] { new ChartSeries { Name = "WAF Blocks", Data = wafBlockSamples.ToArray() } }" />
+        </MetricBlock>
+    </div>
+</MudStack>
 
 @code {
+    using System.Text.Json.Serialization;
+
     private readonly List<string> labels = new();
     private readonly List<double> rpsSamples = new();
     private readonly List<double> uaEntropySamples = new();
@@ -34,6 +40,14 @@
     private int sampleIndex;
     private const int MaxSamples = 20;
     private CancellationTokenSource? cts;
+
+    private readonly GridItem[] defaultLayout = new[]
+    {
+        new GridItem { Id = "rps", X = 0, Y = 0, W = 3, H = 2 },
+        new GridItem { Id = "ua", X = 3, Y = 0, W = 3, H = 2 },
+        new GridItem { Id = "schema", X = 6, Y = 0, W = 3, H = 2 },
+        new GridItem { Id = "waf", X = 9, Y = 0, W = 3, H = 2 }
+    };
 
     protected override async Task OnInitializedAsync()
     {
@@ -45,6 +59,14 @@
         catch (Exception ex)
         {
             Snackbar.Add(ex.Message, Severity.Warning);
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("metricLayout.init", defaultLayout);
         }
     }
 
@@ -73,8 +95,22 @@
             list.RemoveAt(0);
     }
 
+    private async Task ResetLayout()
+    {
+        await JS.InvokeVoidAsync("metricLayout.reset");
+    }
+
     public void Dispose()
     {
         cts?.Cancel();
+    }
+
+    private class GridItem
+    {
+        [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+        [JsonPropertyName("x")] public int X { get; set; }
+        [JsonPropertyName("y")] public int Y { get; set; }
+        [JsonPropertyName("w")] public int W { get; set; }
+        [JsonPropertyName("h")] public int H { get; set; }
     }
 }

--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -10,6 +10,7 @@
     <base href="~/" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack.min.css" rel="stylesheet" />
 </head>
 <body>
     <app>
@@ -19,5 +20,7 @@
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_content/BlazorMonaco/js/monaco.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js"></script>
+    <script src="js/metrics-layout.js"></script>
 </body>
 </html>

--- a/src/ui/dashboard/Shared/MetricBlock.razor
+++ b/src/ui/dashboard/Shared/MetricBlock.razor
@@ -1,0 +1,18 @@
+@using Microsoft.AspNetCore.Components
+
+<div class="grid-stack-item" id="@Id"
+     data-gs-x="@X" data-gs-y="@Y"
+     data-gs-width="@Width" data-gs-height="@Height">
+    <div class="grid-stack-item-content pa-2">
+        @ChildContent
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Id { get; set; } = string.Empty;
+    [Parameter] public int X { get; set; };
+    [Parameter] public int Y { get; set; };
+    [Parameter] public int Width { get; set; } = 3;
+    [Parameter] public int Height { get; set; } = 2;
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+}

--- a/src/ui/dashboard/_Imports.razor
+++ b/src/ui/dashboard/_Imports.razor
@@ -8,3 +8,4 @@
 @using BlazorMonaco.Editor
 @using global::Dashboard.Models
 @using global::Dashboard.Services
+@using global::Dashboard.Shared

--- a/src/ui/dashboard/wwwroot/js/metrics-layout.js
+++ b/src/ui/dashboard/wwwroot/js/metrics-layout.js
@@ -1,0 +1,34 @@
+window.metricLayout = {
+  init: function (defaultLayout) {
+    const grid = GridStack.init({float: true});
+    this.grid = grid;
+    this.defaultLayout = defaultLayout;
+
+    const saved = localStorage.getItem('metrics-layout');
+    if (saved) {
+      try {
+        const nodes = JSON.parse(saved);
+        nodes.forEach(n => {
+          const el = document.getElementById(n.id);
+          if (el) grid.update(el, n);
+        });
+      } catch (e) {
+        console.error('failed to load layout', e);
+      }
+    }
+
+    grid.on('change', () => {
+      const nodes = grid.save(true);
+      localStorage.setItem('metrics-layout', JSON.stringify(nodes));
+    });
+  },
+  reset: function () {
+    const grid = this.grid;
+    if (!grid) return;
+    localStorage.removeItem('metrics-layout');
+    this.defaultLayout.forEach(n => {
+      const el = document.getElementById(n.id);
+      if (el) grid.update(el, n);
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- wrap metric charts in a reusable `MetricBlock` component
- integrate GridStack.js to allow dragging metric blocks and save positions in localStorage
- add reset layout button and gridstack assets

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1748eb43083268c2abff78642ca80