### PR TITLE
feat(ui): add network map visualization

### DIFF
--- a/src/ui/dashboard/Models/NetworkDto.cs
+++ b/src/ui/dashboard/Models/NetworkDto.cs
@@ -1,0 +1,7 @@
+namespace Dashboard.Models;
+
+public record NetworkNodeDto(string Id, string Label, double Latency, int Requests);
+
+public record NetworkEdgeDto(string SourceId, string TargetId, int Requests, double Latency);
+
+public record NetworkGraphDto(IEnumerable<NetworkNodeDto> Nodes, IEnumerable<NetworkEdgeDto> Edges);

--- a/src/ui/dashboard/Options/GatewayOptions.cs
+++ b/src/ui/dashboard/Options/GatewayOptions.cs
@@ -5,5 +5,6 @@ public class GatewayOptions
     public string Metrics { get; set; } = "";
     public string Incidents { get; set; } = "";
     public string Control { get; set; } = "";
+    public string Network { get; set; } = "";
     public string Summarizer { get; set; } = "";
 }

--- a/src/ui/dashboard/Pages/Network.razor
+++ b/src/ui/dashboard/Pages/Network.razor
@@ -1,0 +1,17 @@
+@page "/network"
+@inject INetworkService NetworkService
+@inject IJSRuntime JS
+
+<h3>Network Map</h3>
+<canvas id="networkCanvas" style="width:100%; height:500px;"></canvas>
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var graph = await NetworkService.GetNetworkAsync();
+            await JS.InvokeVoidAsync("renderNetwork", graph);
+        }
+    }
+}

--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -22,5 +22,7 @@
     <script src="_content/BlazorMonaco/js/monaco.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js"></script>
     <script src="js/metrics-layout.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.159.0/build/three.min.js"></script>
+    <script src="js/network.js"></script>
 </body>
 </html>

--- a/src/ui/dashboard/Program.cs
+++ b/src/ui/dashboard/Program.cs
@@ -23,6 +23,7 @@ if (useMocks)
     builder.Services.AddScoped<IIncidentService, MockIncidentService>();
     builder.Services.AddScoped<IControlPlaneService, MockControlPlaneService>();
     builder.Services.AddScoped<ISummarizerService, MockSummarizerService>();
+    builder.Services.AddScoped<INetworkService, MockNetworkService>();
 }
 else
 {
@@ -46,10 +47,17 @@ else
         var opts = sp.GetRequiredService<IOptions<GatewayOptions>>().Value;
         client.BaseAddress = new Uri(opts.Summarizer);
     });
+    builder.Services.AddHttpClient<RealNetworkService>((sp, client) =>
+    {
+        var opts = sp.GetRequiredService<IOptions<GatewayOptions>>().Value;
+        client.BaseAddress = new Uri(opts.Network);
+    });
+
     builder.Services.AddScoped<IMetricsService, RealMetricsService>();
     builder.Services.AddScoped<IIncidentService, RealIncidentService>();
     builder.Services.AddScoped<IControlPlaneService, RealControlPlaneService>();
     builder.Services.AddScoped<ISummarizerService, RealSummarizerService>();
+    builder.Services.AddScoped<INetworkService, RealNetworkService>();
 }
 
 var app = builder.Build();

--- a/src/ui/dashboard/Services/INetworkService.cs
+++ b/src/ui/dashboard/Services/INetworkService.cs
@@ -1,0 +1,8 @@
+using Dashboard.Models;
+
+namespace Dashboard.Services;
+
+public interface INetworkService
+{
+    Task<NetworkGraphDto> GetNetworkAsync();
+}

--- a/src/ui/dashboard/Services/Mock/MockNetworkService.cs
+++ b/src/ui/dashboard/Services/Mock/MockNetworkService.cs
@@ -1,0 +1,22 @@
+using Dashboard.Models;
+
+namespace Dashboard.Services.Mock;
+
+public class MockNetworkService : INetworkService
+{
+    public Task<NetworkGraphDto> GetNetworkAsync()
+    {
+        var nodes = new[]
+        {
+            new NetworkNodeDto("gateway", "Gateway", 10, 120),
+            new NetworkNodeDto("api", "API", 25, 80),
+            new NetworkNodeDto("db", "Database", 40, 40)
+        };
+        var edges = new[]
+        {
+            new NetworkEdgeDto("gateway", "api", 80, 25),
+            new NetworkEdgeDto("api", "db", 40, 40)
+        };
+        return Task.FromResult(new NetworkGraphDto(nodes, edges));
+    }
+}

--- a/src/ui/dashboard/Services/Real/RealNetworkService.cs
+++ b/src/ui/dashboard/Services/Real/RealNetworkService.cs
@@ -1,0 +1,14 @@
+using System.Net.Http.Json;
+using Dashboard.Models;
+
+namespace Dashboard.Services.Real;
+
+public class RealNetworkService : INetworkService
+{
+    private readonly HttpClient _http;
+    public RealNetworkService(HttpClient http) => _http = http;
+
+    public async Task<NetworkGraphDto> GetNetworkAsync()
+        => await _http.GetFromJsonAsync<NetworkGraphDto>("network/map")
+            ?? new NetworkGraphDto(Array.Empty<NetworkNodeDto>(), Array.Empty<NetworkEdgeDto>());
+}

--- a/src/ui/dashboard/Shared/NavMenu.razor
+++ b/src/ui/dashboard/Shared/NavMenu.razor
@@ -4,4 +4,5 @@
     <MudNavLink Href="/metrics" Icon="@Icons.Material.Filled.ShowChart" AccessKey="m">Metrics</MudNavLink>
     <MudNavLink Href="/incidents" Icon="@Icons.Material.Filled.List" AccessKey="i">Incidents</MudNavLink>
     <MudNavLink Href="/policies" Icon="@Icons.Material.Filled.Policy" AccessKey="p">Policies</MudNavLink>
+    <MudNavLink Href="/network" Icon="@Icons.Material.Filled.DeviceHub" Class="network-link" AccessKey="n">Network Map</MudNavLink>
 </MudNavMenu>

--- a/src/ui/dashboard/_Imports.razor
+++ b/src/ui/dashboard/_Imports.razor
@@ -2,6 +2,7 @@
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.JSInterop
 @using Microsoft.AspNetCore.Components.Web
 @using MudBlazor
 @using BlazorMonaco

--- a/src/ui/dashboard/appsettings.json
+++ b/src/ui/dashboard/appsettings.json
@@ -4,6 +4,7 @@
     "Metrics": "https://localhost:5001",
     "Incidents": "https://localhost:5001",
     "Control": "https://localhost:5001",
+    "Network": "https://localhost:5001",
     "Summarizer": "http://localhost:5290"
   }
 }

--- a/src/ui/dashboard/wwwroot/css/app.css
+++ b/src/ui/dashboard/wwwroot/css/app.css
@@ -69,3 +69,12 @@ html {
     color: var(--mud-palette-primary);
 }
 
+.network-link .mud-nav-link-icon {
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
+}

--- a/src/ui/dashboard/wwwroot/js/network.js
+++ b/src/ui/dashboard/wwwroot/js/network.js
@@ -1,0 +1,35 @@
+window.renderNetwork = (graph) => {
+    const canvas = document.getElementById('networkCanvas');
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+    const renderer = new THREE.WebGLRenderer({ canvas });
+    renderer.setSize(width, height);
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    camera.position.z = 5;
+
+    const positions = graph.nodes.map((n, i) => {
+        const angle = (i / graph.nodes.length) * Math.PI * 2;
+        return new THREE.Vector3(Math.cos(angle) * 2, Math.sin(angle) * 2, 0);
+    });
+
+    graph.nodes.forEach((n, i) => {
+        const geometry = new THREE.SphereGeometry(0.1, 16, 16);
+        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.position.copy(positions[i]);
+        scene.add(mesh);
+    });
+
+    graph.edges.forEach(e => {
+        const src = positions[graph.nodes.findIndex(n => n.id === e.sourceId)];
+        const dst = positions[graph.nodes.findIndex(n => n.id === e.targetId)];
+        const material = new THREE.LineBasicMaterial({ color: 0x0000ff });
+        const points = [src, dst];
+        const geometry = new THREE.BufferGeometry().setFromPoints(points);
+        const line = new THREE.Line(geometry, material);
+        scene.add(line);
+    });
+
+    renderer.render(scene, camera);
+};


### PR DESCRIPTION
## Summary
- add network map page using Three.js
- pull node and edge data from gateway services
- link network map in navigation with animated icon

## Testing
- `dotnet build src/ui/dashboard/Dashboard.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b175bf5b2c8326834a06ad8de35cfb