### PR TITLE
Fix GridStack initialization on Metrics page

### DIFF
--- a/src/ui/dashboard/Pages/Metrics.razor
+++ b/src/ui/dashboard/Pages/Metrics.razor
@@ -4,6 +4,7 @@
 @inject IMetricsService MetricsService
 @inject ISnackbar Snackbar
 @inject IJSRuntime JS
+@implements IAsyncDisposable
 
 <MudStack Class="pa-4" Spacing="2">
     <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" OnClick="ResetLayout">Reset layout</MudButton>
@@ -54,6 +55,7 @@
     private int sampleIndex;
     private const int MaxSamples = 20;
     private CancellationTokenSource? cts;
+    private IJSObjectReference? module;
 
     private readonly GridItem[] defaultLayout = new[]
     {
@@ -80,7 +82,8 @@
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("metricLayout.init", defaultLayout);
+            module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/metrics-layout.js");
+            await module.InvokeVoidAsync("init", defaultLayout);
         }
     }
 
@@ -111,12 +114,19 @@
 
     private async Task ResetLayout()
     {
-        await JS.InvokeVoidAsync("metricLayout.reset");
+        if (module != null)
+        {
+            await module.InvokeVoidAsync("reset");
+        }
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         cts?.Cancel();
+        if (module != null)
+        {
+            await module.DisposeAsync();
+        }
     }
 
     class GridItem

--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -20,9 +20,7 @@
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_content/BlazorMonaco/js/monaco.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js"></script>
-    <script src="js/metrics-layout.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.159.0/build/three.min.js"></script>
     <script src="js/network.js"></script>
-</body>
+  </body>
 </html>

--- a/src/ui/dashboard/wwwroot/js/metrics-layout.js
+++ b/src/ui/dashboard/wwwroot/js/metrics-layout.js
@@ -1,34 +1,36 @@
-window.metricLayout = {
-  init: function (defaultLayout) {
-    const grid = GridStack.init({float: true});
-    this.grid = grid;
-    this.defaultLayout = defaultLayout;
+import { GridStack } from 'https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js';
 
-    const saved = localStorage.getItem('metrics-layout');
-    if (saved) {
-      try {
-        const nodes = JSON.parse(saved);
-        nodes.forEach(n => {
-          const el = document.getElementById(n.id);
-          if (el) grid.update(el, n);
-        });
-      } catch (e) {
-        console.error('failed to load layout', e);
-      }
+let grid;
+let defaultLayout;
+
+export function init(layout) {
+  grid = GridStack.init({ float: true });
+  defaultLayout = layout;
+
+  const saved = localStorage.getItem('metrics-layout');
+  if (saved) {
+    try {
+      const nodes = JSON.parse(saved);
+      nodes.forEach(n => {
+        const el = document.getElementById(n.id);
+        if (el) grid.update(el, n);
+      });
+    } catch (e) {
+      console.error('failed to load layout', e);
     }
-
-    grid.on('change', () => {
-      const nodes = grid.save(true);
-      localStorage.setItem('metrics-layout', JSON.stringify(nodes));
-    });
-  },
-  reset: function () {
-    const grid = this.grid;
-    if (!grid) return;
-    localStorage.removeItem('metrics-layout');
-    this.defaultLayout.forEach(n => {
-      const el = document.getElementById(n.id);
-      if (el) grid.update(el, n);
-    });
   }
-};
+
+  grid.on('change', () => {
+    const nodes = grid.save(true);
+    localStorage.setItem('metrics-layout', JSON.stringify(nodes));
+  });
+}
+
+export function reset() {
+  if (!grid) return;
+  localStorage.removeItem('metrics-layout');
+  defaultLayout.forEach(n => {
+    const el = document.getElementById(n.id);
+    if (el) grid.update(el, n);
+  });
+}


### PR DESCRIPTION
## Summary
- load GridStack via ES module in metrics layout script
- initialize and reset layout from a JS module imported in Metrics.razor
- remove unused gridstack script tags from host page

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c6317f6083269ca0ca9616c16be9