### PR TITLE
Fix JavaScript interop during prerender

### DIFF
--- a/src/ui/dashboard/Shared/MainLayout.razor
+++ b/src/ui/dashboard/Shared/MainLayout.razor
@@ -43,21 +43,18 @@
     private bool isNavMenuOpen;
     private IDisposable? breakpointSubscription;
 
-    protected override async Task OnInitializedAsync()
-    {
-        var breakpoint = await BreakpointService.GetBreakpoint();
-        isNavMenuOpen = breakpoint >= Breakpoint.Md;
-        breakpointSubscription = BreakpointService.Subscribe(bp =>
-        {
-            isNavMenuOpen = bp >= Breakpoint.Md;
-            InvokeAsync(StateHasChanged);
-        });
-    }
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            var breakpoint = await BreakpointService.GetBreakpoint();
+            isNavMenuOpen = breakpoint >= Breakpoint.Md;
+            breakpointSubscription = BreakpointService.Subscribe(bp =>
+            {
+                isNavMenuOpen = bp >= Breakpoint.Md;
+                InvokeAsync(StateHasChanged);
+            });
+
             await ThemeManager.InitializeAsync();
             StateHasChanged();
         }


### PR DESCRIPTION
## Summary
- Avoid calling breakpoint service during static render to fix JS interop error

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c7bb072c8326b9e29367439dd191