### PR TITLE
Ensure layout shows mini icons on small screens

### DIFF
--- a/src/ui/dashboard/Shared/MainLayout.razor
+++ b/src/ui/dashboard/Shared/MainLayout.razor
@@ -20,7 +20,7 @@
             <MudChip Color="Color.Error" Variant="Variant.Filled">ALPHA</MudChip>
         </MudAppBar>
         <MudDrawerContainer>
-            <MudDrawer @bind-Open="isNavMenuOpen" ClipMode="DrawerClipMode.Never" Variant="DrawerVariant.Responsive" MiniVariant="DrawerVariant.Mini" Breakpoint="Breakpoint.Md">
+            <MudDrawer @bind-Open="isNavMenuOpen" Variant="DrawerVariant.Mini" ClipMode="DrawerClipMode.Always" MiniVariantWidth="56px">
                 <NavMenu />
             </MudDrawer>
             <MudMainContent Class="app-background mud-main-content">


### PR DESCRIPTION
## Summary
- Keep side drawer in mini variant with icons when screen is small
- Clip drawer under the app bar to avoid top bar overlapping content

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c94556e48326b8a7e4126ed50e1d