### PR TITLE
Fix Metrics page JS module import failure

### DIFF
--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -18,7 +18,6 @@
     </app>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/4.2.5/gridstack.all.min.js"></script>
-    <script src="js/metrics-layout.js"></script>
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_content/BlazorMonaco/js/monaco.js"></script>

--- a/src/ui/dashboard/wwwroot/js/metrics-layout.js
+++ b/src/ui/dashboard/wwwroot/js/metrics-layout.js
@@ -1,5 +1,3 @@
-import { GridStack } from 'https://cdn.jsdelivr.net/npm/gridstack@9.3.0/dist/gridstack-h5.js';
-
 let grid;
 let defaultLayout;
 


### PR DESCRIPTION
## Summary
- Avoid dynamic import failure by referencing globally loaded GridStack instead of CDN module
- Drop redundant metrics layout script tag from host page

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c9795cf883268e80359e8ba74be1