### PR TITLE
Fix dashboard content overlapping top bar

### DIFF
--- a/src/ui/dashboard/Shared/MainLayout.razor
+++ b/src/ui/dashboard/Shared/MainLayout.razor
@@ -19,14 +19,12 @@
             <MudIconButton Icon="@(ThemeManager.IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)" Color="Color.Inherit" OnClick="ToggleTheme" />
             <MudChip Color="Color.Error" Variant="Variant.Filled">ALPHA</MudChip>
         </MudAppBar>
-        <MudDrawerContainer>
-            <MudDrawer @bind-Open="isNavMenuOpen" Variant="DrawerVariant.Mini" ClipMode="DrawerClipMode.Always" MiniVariantWidth="56px">
-                <NavMenu />
-            </MudDrawer>
-            <MudMainContent Class="app-background mud-main-content">
-                @Body
-            </MudMainContent>
-        </MudDrawerContainer>
+        <MudDrawer @bind-Open="isNavMenuOpen" Variant="DrawerVariant.Mini" ClipMode="DrawerClipMode.Always" MiniVariantWidth="56px">
+            <NavMenu />
+        </MudDrawer>
+        <MudMainContent Class="app-background mud-main-content">
+            @Body
+        </MudMainContent>
     </MudLayout>
     @if (UseMocks)
     {

--- a/src/ui/dashboard/wwwroot/css/app.css
+++ b/src/ui/dashboard/wwwroot/css/app.css
@@ -95,6 +95,7 @@ html {
 /* Ensure the main content respects the drawer's width */
 .mud-main-content {
     margin-left: 0;
+    margin-top: var(--mud-appbar-height);
     transition: margin-left 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `MudDrawerContainer` so AppBar height offsets content
- Add `margin-top: var(--mud-appbar-height)` to main content

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cb2e5e4c832691ed75b43e7fed4f