### PR TITLE
Fix Policies editor initialization for BlazorMonaco

### DIFF
--- a/src/ui/dashboard/Pages/Policies.razor
+++ b/src/ui/dashboard/Pages/Policies.razor
@@ -3,7 +3,7 @@
 @inject IControlPlaneService ControlService
 @inject ISnackbar Snackbar
 
-<MonacoEditor @ref="editor" @bind-Value="policy" Options="editorOptions" Height="300px" Class="ma-2" />
+<MonacoEditor @ref="editor" @bind-Value="policy" ConstructionOptions="editorOptions" Height="300px" Class="ma-2" />
 <MudButton OnClick="Validate" Color="Color.Primary">Validate</MudButton>
 <MudButton OnClick="Format" Color="Color.Secondary">Format</MudButton>
 <MudButton OnClick="Save" Color="Color.Success">Save</MudButton>


### PR DESCRIPTION
## Summary
- fix Policies editor component by using ConstructionOptions for BlazorMonaco

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cbf0b4ec8326a3e65ae6032cc918