### PR TITLE
Handle missing grid library on metrics dashboard

### DIFF
--- a/src/ui/dashboard/Pages/Metrics.razor
+++ b/src/ui/dashboard/Pages/Metrics.razor
@@ -11,35 +11,35 @@
     <div class="grid-stack">
         <MetricBlock Id="rps" X="0" Y="0" Width="3" Height="2">
             <MudChart ChartType="ChartType.Line"
-                      XAxisLabels="@labels.ToArray()"
+                      XAxisLabels="@GetLabels()"
                       Series="@(
                                     new ChartSeries[] {
-                                        new() { Name = "Requests/s", Data = rpsSamples.ToArray() }
+                                        new() { Name = "Requests/s", Data = GetData(rpsSamples) }
                                     })" />
         </MetricBlock>
         <MetricBlock Id="ua" X="3" Y="0" Width="3" Height="2">
             <MudChart ChartType="ChartType.Line"
-                      XAxisLabels="@labels.ToArray()"
+                      XAxisLabels="@GetLabels()"
                       Series="@(
                                     new ChartSeries[] {
-                                        new() { Name = "UA Entropy", Data = uaEntropySamples.ToArray() }
+                                        new() { Name = "UA Entropy", Data = GetData(uaEntropySamples) }
                                     })" />
         </MetricBlock>
         <MetricBlock Id="schema" X="6" Y="0" Width="3" Height="2">
 
                                                 <MudChart ChartType="ChartType.Line"
-                                                          XAxisLabels="@labels.ToArray()"
+                                                          XAxisLabels="@GetLabels()"
                                                           Series="@(
                                     new ChartSeries[] {
-                                        new() { Name = "Schema Errors", Data = schemaErrorSamples.ToArray() }
+                                        new() { Name = "Schema Errors", Data = GetData(schemaErrorSamples) }
                                     })" />
         </MetricBlock>
         <MetricBlock Id="waf" X="9" Y="0" Width="3" Height="2">
             <MudChart ChartType="ChartType.Line"
-                      XAxisLabels="@labels.ToArray()"
+                      XAxisLabels="@GetLabels()"
                       Series="@(
                                     new ChartSeries[] {
-                                        new() { Name = "WAF Blocks", Data = wafBlockSamples.ToArray() }
+                                        new() { Name = "WAF Blocks", Data = GetData(wafBlockSamples) }
                                     })" />
         </MetricBlock>
     </div>
@@ -111,6 +111,12 @@
         if (list.Count > MaxSamples)
             list.RemoveAt(0);
     }
+
+    private string[] GetLabels()
+        => labels.Count > 0 ? labels.ToArray() : new[] { "0" };
+
+    private static double[] GetData(List<double> samples)
+        => samples.Count > 0 ? samples.ToArray() : new double[] { 0 };
 
     private async Task ResetLayout()
     {

--- a/src/ui/dashboard/wwwroot/js/metrics-layout.js
+++ b/src/ui/dashboard/wwwroot/js/metrics-layout.js
@@ -1,7 +1,21 @@
 let grid;
 let defaultLayout;
 
-export function init(layout) {
+async function ensureGridStack() {
+  if (window.GridStack) return;
+
+  await new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/4.2.5/gridstack.all.min.js';
+    script.onload = resolve;
+    script.onerror = () => reject(new Error('failed to load GridStack'));
+    document.head.appendChild(script);
+  });
+}
+
+export async function init(layout) {
+  await ensureGridStack();
+
   const GridStackLib = window.GridStack;
   if (!GridStackLib) {
     console.error('GridStack library is missing');


### PR DESCRIPTION
## Summary
- Load GridStack library dynamically if missing to restore metrics dashboard layout
- Ensure charts render with default values to avoid NaN rendering errors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cdab6e648326aec46593c836e68c