### PR TITLE
Handle missing GridStack and avoid empty charts on metrics page

### DIFF
--- a/src/ui/dashboard/Pages/Metrics.razor
+++ b/src/ui/dashboard/Pages/Metrics.razor
@@ -10,37 +10,48 @@
     <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" OnClick="ResetLayout">Reset layout</MudButton>
     <div class="grid-stack">
         <MetricBlock Id="rps" X="0" Y="0" Width="3" Height="2">
-            <MudChart ChartType="ChartType.Line"
-                      XAxisLabels="@GetLabels()"
-                      Series="@(
-                                    new ChartSeries[] {
-                                        new() { Name = "Requests/s", Data = GetData(rpsSamples) }
-                                    })" />
+            @if (HasData(rpsSamples))
+            {
+                <MudChart ChartType="ChartType.Line"
+                          XAxisLabels="@GetLabels()"
+                          Series="@(
+                                        new ChartSeries[] {
+                                            new() { Name = "Requests/s", Data = GetData(rpsSamples) }
+                                        })" />
+            }
         </MetricBlock>
         <MetricBlock Id="ua" X="3" Y="0" Width="3" Height="2">
-            <MudChart ChartType="ChartType.Line"
-                      XAxisLabels="@GetLabels()"
-                      Series="@(
-                                    new ChartSeries[] {
-                                        new() { Name = "UA Entropy", Data = GetData(uaEntropySamples) }
-                                    })" />
+            @if (HasData(uaEntropySamples))
+            {
+                <MudChart ChartType="ChartType.Line"
+                          XAxisLabels="@GetLabels()"
+                          Series="@(
+                                        new ChartSeries[] {
+                                            new() { Name = "UA Entropy", Data = GetData(uaEntropySamples) }
+                                        })" />
+            }
         </MetricBlock>
         <MetricBlock Id="schema" X="6" Y="0" Width="3" Height="2">
-
-                                                <MudChart ChartType="ChartType.Line"
-                                                          XAxisLabels="@GetLabels()"
-                                                          Series="@(
-                                    new ChartSeries[] {
-                                        new() { Name = "Schema Errors", Data = GetData(schemaErrorSamples) }
-                                    })" />
+            @if (HasData(schemaErrorSamples))
+            {
+                <MudChart ChartType="ChartType.Line"
+                          XAxisLabels="@GetLabels()"
+                          Series="@(
+                                        new ChartSeries[] {
+                                            new() { Name = "Schema Errors", Data = GetData(schemaErrorSamples) }
+                                        })" />
+            }
         </MetricBlock>
         <MetricBlock Id="waf" X="9" Y="0" Width="3" Height="2">
-            <MudChart ChartType="ChartType.Line"
-                      XAxisLabels="@GetLabels()"
-                      Series="@(
-                                    new ChartSeries[] {
-                                        new() { Name = "WAF Blocks", Data = GetData(wafBlockSamples) }
-                                    })" />
+            @if (HasData(wafBlockSamples))
+            {
+                <MudChart ChartType="ChartType.Line"
+                          XAxisLabels="@GetLabels()"
+                          Series="@(
+                                        new ChartSeries[] {
+                                            new() { Name = "WAF Blocks", Data = GetData(wafBlockSamples) }
+                                        })" />
+            }
         </MetricBlock>
     </div>
 </MudStack>
@@ -113,10 +124,13 @@
     }
 
     private string[] GetLabels()
-        => labels.Count > 0 ? labels.ToArray() : new[] { "0" };
+        => labels.Count > 0 ? labels.ToArray() : Array.Empty<string>();
 
     private static double[] GetData(List<double> samples)
-        => samples.Count > 0 ? samples.ToArray() : new double[] { 0 };
+        => samples.Count > 0 ? samples.ToArray() : Array.Empty<double>();
+
+    private static bool HasData(List<double> samples)
+        => samples.Count > 0;
 
     private async Task ResetLayout()
     {

--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -17,7 +17,6 @@
         <component type="typeof(App)" render-mode="ServerPrerendered" />
     </app>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/4.2.5/gridstack.all.min.js"></script>
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_content/BlazorMonaco/js/monaco.js"></script>

--- a/src/ui/dashboard/wwwroot/js/metrics-layout.js
+++ b/src/ui/dashboard/wwwroot/js/metrics-layout.js
@@ -1,22 +1,10 @@
+import { GridStack } from 'https://cdn.jsdelivr.net/npm/gridstack@4.2.5/dist/gridstack-h5.js';
+
 let grid;
 let defaultLayout;
 
-async function ensureGridStack() {
-  if (window.GridStack) return;
-
-  await new Promise((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/4.2.5/gridstack.all.min.js';
-    script.onload = resolve;
-    script.onerror = () => reject(new Error('failed to load GridStack'));
-    document.head.appendChild(script);
-  });
-}
-
 export async function init(layout) {
-  await ensureGridStack();
-
-  const GridStackLib = window.GridStack;
+  const GridStackLib = GridStack;
   if (!GridStackLib) {
     console.error('GridStack library is missing');
     return;


### PR DESCRIPTION
## Summary
- Load GridStack via ES module and drop legacy script tag
- Only render metrics charts when sample data exists to avoid NaN rendering errors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cece6e0483268bdb97bc5aa7b6b6