### PR TITLE
Remove BlazorMonaco from policies page

### DIFF
--- a/src/ui/dashboard/Dashboard.csproj
+++ b/src/ui/dashboard/Dashboard.csproj
@@ -7,6 +7,5 @@
   <ItemGroup>
     <PackageReference Include="MudBlazor" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
-    <PackageReference Include="BlazorMonaco" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/ui/dashboard/Pages/Policies.razor
+++ b/src/ui/dashboard/Pages/Policies.razor
@@ -3,10 +3,9 @@
 @inject IControlPlaneService ControlService
 @inject ISnackbar Snackbar
 
-<MonacoEditor @ref="editor"
+<MudTextField T="string"
               @bind-Value="policy"
-              ConstructionOptions="@(e => new StandaloneEditorConstructionOptions { Language = "json", AutomaticLayout = true })"
-              Height="300px"
+              Lines="15"
               Class="ma-2" />
 <MudButton OnClick="Validate" Color="Color.Primary">Validate</MudButton>
 <MudButton OnClick="Format" Color="Color.Secondary">Format</MudButton>
@@ -14,13 +13,7 @@
 <MudButton OnClick="SuggestPatch" Color="Color.Info">Suggerisci patch</MudButton>
 
 @code {
-    private MonacoEditor? editor;
     private string policy = "{}";
-    private StandaloneEditorConstructionOptions editorOptions = new()
-    {
-        Language = "json",
-        AutomaticLayout = true
-    };
 
     protected override async Task OnInitializedAsync()
     {
@@ -47,15 +40,12 @@
         }
     }
 
-    private async Task Format()
+    private void Format()
     {
         try
         {
-            if (editor is not null)
-            {
-                await editor.Trigger("keyboard", "editor.action.formatDocument", default(JsonElement));
-                policy = await editor.GetValue();
-            }
+            var element = JsonSerializer.Deserialize<JsonElement>(policy);
+            policy = JsonSerializer.Serialize(element, new JsonSerializerOptions { WriteIndented = true });
         }
         catch
         {
@@ -67,8 +57,6 @@
     {
         try
         {
-            if (editor is not null)
-                policy = await editor.GetValue();
             await ControlService.SavePolicyAsync(policy);
             Snackbar.Add("Policy saved", Severity.Success);
         }
@@ -82,8 +70,6 @@
     {
         try
         {
-            if (editor is not null)
-                policy = await editor.GetValue();
             policy = await ControlService.SuggestPolicyPatchAsync(policy);
         }
         catch (Exception ex)

--- a/src/ui/dashboard/Pages/_Host.cshtml
+++ b/src/ui/dashboard/Pages/_Host.cshtml
@@ -20,7 +20,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/4.2.5/gridstack.all.min.js"></script>
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
-    <script src="_content/BlazorMonaco/js/monaco.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.159.0/build/three.min.js"></script>
     <script src="js/network.js"></script>
   </body>

--- a/src/ui/dashboard/_Imports.razor
+++ b/src/ui/dashboard/_Imports.razor
@@ -6,7 +6,6 @@
 @using Microsoft.AspNetCore.Components.Web
 @using MudBlazor
 @using MudBlazor.Services
-@using BlazorMonaco
 @using global::Dashboard.Models
 @using global::Dashboard.Services
 @using global::Dashboard.Shared


### PR DESCRIPTION
## Summary
- Replace BlazorMonaco editor with MudTextField for policy editing
- Drop BlazorMonaco package, import, and script references

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cf78c030832693b94c1de32b904c