### PR TITLE
feat(ui): add control plane management page

### DIFF
--- a/src/ui/dashboard/Models/ApiKeyDto.cs
+++ b/src/ui/dashboard/Models/ApiKeyDto.cs
@@ -1,0 +1,3 @@
+namespace Dashboard.Models;
+
+public record ApiKeyDto(string Id, string Name, string Key);

--- a/src/ui/dashboard/Models/AuditEntryDto.cs
+++ b/src/ui/dashboard/Models/AuditEntryDto.cs
@@ -1,0 +1,3 @@
+namespace Dashboard.Models;
+
+public record AuditEntryDto(DateTime Timestamp, string Action, string Subject);

--- a/src/ui/dashboard/Models/RateLimitPlanDto.cs
+++ b/src/ui/dashboard/Models/RateLimitPlanDto.cs
@@ -1,0 +1,3 @@
+namespace Dashboard.Models;
+
+public record RateLimitPlanDto(string Plan, int Rpm);

--- a/src/ui/dashboard/Models/RouteDto.cs
+++ b/src/ui/dashboard/Models/RouteDto.cs
@@ -1,0 +1,3 @@
+namespace Dashboard.Models;
+
+public record RouteDto(string Id, string Path, string Destination);

--- a/src/ui/dashboard/Models/WafRuleDto.cs
+++ b/src/ui/dashboard/Models/WafRuleDto.cs
@@ -1,0 +1,3 @@
+namespace Dashboard.Models;
+
+public record WafRuleDto(string Rule, bool Enabled);

--- a/src/ui/dashboard/Pages/Policies.razor
+++ b/src/ui/dashboard/Pages/Policies.razor
@@ -1,96 +1,93 @@
 @page "/policies"
-@using System.Text.Json
-@using Dashboard.Services.Mock
+@using Dashboard.Models
+@using System.Linq
 @inject IControlPlaneService ControlService
-@inject ISnackbar Snackbar
 
-<MudText Class="ma-2">
-This page lets you view and edit the gateway policy. It loads and saves the policy
-    through the <code>IControlPlaneService</code>.
-    @if (ControlService is MockControlPlaneService)
-    {
-        <text>The mock service stores the policy in memory for demonstration.</text>
-    }
-    else
-    {
-        <text>Real control plane endpoints are not implemented yet.</text>
-    }
-</MudText>
-
-<MudTextField T="string"
-              @bind-Value="policy"
-              Lines="15"
-              Class="ma-2"
-              Variant="Variant.Outlined"
-              Style="font-family:monospace;" />
-<MudButton OnClick="Validate" Color="Color.Primary">Validate</MudButton>
-<MudButton OnClick="Format" Color="Color.Secondary">Format</MudButton>
-<MudButton OnClick="Save" Color="Color.Success">Save</MudButton>
-<MudButton OnClick="SuggestPatch" Color="Color.Info">Suggest patch</MudButton>
+<MudTabs>
+    <MudTabPanel Text="API Keys" Icon="@Icons.Material.Filled.VpnKey">
+        <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" Class="mb-2">Add</MudButton>
+        <MudTable Items="_apiKeys" Striped="true" Hover="true">
+            <HeaderContent>
+                <MudTh>Id</MudTh>
+                <MudTh>Name</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Id">@context.Id</MudTd>
+                <MudTd DataLabel="Name">@context.Name</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+    <MudTabPanel Text="Routes" Icon="@Icons.Material.Filled.AltRoute">
+        <MudButton Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Add" Class="mb-2">Add</MudButton>
+        <MudTable Items="_routes" Striped="true" Hover="true">
+            <HeaderContent>
+                <MudTh>Id</MudTh>
+                <MudTh>Path</MudTh>
+                <MudTh>Destination</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Id">@context.Id</MudTd>
+                <MudTd DataLabel="Path">@context.Path</MudTd>
+                <MudTd DataLabel="Destination">@context.Destination</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+    <MudTabPanel Text="Rate Limits" Icon="@Icons.Material.Filled.Speed">
+        <MudButton Color="Color.Info" StartIcon="@Icons.Material.Filled.Add" Class="mb-2">Add</MudButton>
+        <MudTable Items="_plans" Striped="true" Hover="true">
+            <HeaderContent>
+                <MudTh>Plan</MudTh>
+                <MudTh>RPM</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Plan">@context.Plan</MudTd>
+                <MudTd DataLabel="RPM">@context.Rpm</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+    <MudTabPanel Text="WAF" Icon="@Icons.Material.Filled.Security">
+        <MudTable Items="_waf" Striped="true" Hover="true">
+            <HeaderContent>
+                <MudTh>Rule</MudTh>
+                <MudTh>Enabled</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Rule">@context.Rule</MudTd>
+                <MudTd DataLabel="Enabled">
+                    <MudSwitch @bind-Checked="context.Enabled" Color="Color.Success" />
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+    <MudTabPanel Text="Audit" Icon="@Icons.Material.Filled.History">
+        <MudTable Items="_audit" Striped="true" Hover="true">
+            <HeaderContent>
+                <MudTh>Time</MudTh>
+                <MudTh>Action</MudTh>
+                <MudTh>Subject</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Time">@context.Timestamp.ToLocalTime()</MudTd>
+                <MudTd DataLabel="Action">@context.Action</MudTd>
+                <MudTd DataLabel="Subject">@context.Subject</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudTabPanel>
+</MudTabs>
 
 @code {
-    private string policy = "{}";
+    private List<ApiKeyDto> _apiKeys = new();
+    private List<RouteDto> _routes = new();
+    private List<RateLimitPlanDto> _plans = new();
+    private List<WafRuleDto> _waf = new();
+    private List<AuditEntryDto> _audit = new();
 
     protected override async Task OnInitializedAsync()
     {
-        try
-        {
-            policy = await ControlService.LoadPolicyAsync();
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add(ex.Message, Severity.Warning);
-        }
-    }
-
-    private void Validate()
-    {
-        try
-        {
-            using var doc = JsonDocument.Parse(policy);
-            Snackbar.Add("Policy valid", Severity.Success);
-        }
-        catch
-        {
-            Snackbar.Add("Invalid JSON", Severity.Error);
-        }
-    }
-
-    private void Format()
-    {
-        try
-        {
-            var element = JsonSerializer.Deserialize<JsonElement>(policy);
-            policy = JsonSerializer.Serialize(element, new JsonSerializerOptions { WriteIndented = true });
-        }
-        catch
-        {
-            Snackbar.Add("Invalid JSON", Severity.Error);
-        }
-    }
-
-    private async Task Save()
-    {
-        try
-        {
-            await ControlService.SavePolicyAsync(policy);
-            Snackbar.Add("Policy saved", Severity.Success);
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add(ex.Message, Severity.Warning);
-        }
-    }
-
-    private async Task SuggestPatch()
-    {
-        try
-        {
-            policy = await ControlService.SuggestPolicyPatchAsync(policy);
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add(ex.Message, Severity.Warning);
-        }
+        _apiKeys = (await ControlService.GetApiKeysAsync()).ToList();
+        _routes = (await ControlService.GetRoutesAsync()).ToList();
+        _plans = (await ControlService.GetRateLimitPlansAsync()).ToList();
+        _waf = (await ControlService.GetWafRulesAsync()).ToList();
+        _audit = (await ControlService.GetAuditEntriesAsync()).ToList();
     }
 }

--- a/src/ui/dashboard/Services/IControlPlaneService.cs
+++ b/src/ui/dashboard/Services/IControlPlaneService.cs
@@ -1,9 +1,24 @@
+using Dashboard.Models;
+
 namespace Dashboard.Services;
 
 public interface IControlPlaneService
 {
     Task ApplyFixAsync(string incidentId);
-    Task<string> LoadPolicyAsync();
-    Task SavePolicyAsync(string policyJson);
-    Task<string> SuggestPolicyPatchAsync(string policyJson);
+    Task<IReadOnlyList<ApiKeyDto>> GetApiKeysAsync();
+    Task<ApiKeyDto> CreateApiKeyAsync(ApiKeyDto key);
+    Task DeleteApiKeyAsync(string id);
+
+    Task<IReadOnlyList<RouteDto>> GetRoutesAsync();
+    Task<RouteDto> CreateRouteAsync(RouteDto route);
+    Task DeleteRouteAsync(string id);
+
+    Task<IReadOnlyList<RateLimitPlanDto>> GetRateLimitPlansAsync();
+    Task<RateLimitPlanDto> CreateRateLimitPlanAsync(RateLimitPlanDto plan);
+    Task DeleteRateLimitPlanAsync(string plan);
+
+    Task<IReadOnlyList<WafRuleDto>> GetWafRulesAsync();
+    Task ToggleWafRuleAsync(string rule, bool enabled);
+
+    Task<IReadOnlyList<AuditEntryDto>> GetAuditEntriesAsync();
 }

--- a/src/ui/dashboard/Services/Mock/MockControlPlaneService.cs
+++ b/src/ui/dashboard/Services/Mock/MockControlPlaneService.cs
@@ -1,38 +1,84 @@
+using Dashboard.Models;
+using System.Linq;
+
 namespace Dashboard.Services.Mock;
 
 public class MockControlPlaneService : IControlPlaneService
 {
-    private string _policy = """
-{
-  "routes": [
+    private readonly List<ApiKeyDto> _apiKeys = new()
     {
-      "id": "api",
-      "path": "/api/{**catchall}",
-      "destination": "https://backend/api",
-      "authorizationPolicy": "ApiReadOrKey"
-    }
-  ],
-  "rateLimits": [
-    { "plan": "free", "rpm": 60 }
-  ],
-  "waf": [
-    { "rule": "SqlInjection", "enabled": true }
-  ]
-}
-""";
+        new ApiKeyDto("1", "Demo", "abc123")
+    };
+
+    private readonly List<RouteDto> _routes = new()
+    {
+        new RouteDto("api", "/api/{**catchall}", "https://backend/api")
+    };
+
+    private readonly List<RateLimitPlanDto> _plans = new()
+    {
+        new RateLimitPlanDto("free", 60)
+    };
+
+    private readonly List<WafRuleDto> _waf = new()
+    {
+        new WafRuleDto("SqlInjection", true)
+    };
+
+    private readonly List<AuditEntryDto> _audit = new()
+    {
+        new AuditEntryDto(DateTime.UtcNow, "created", "Demo")
+    };
 
     public Task ApplyFixAsync(string incidentId) => Task.CompletedTask;
 
-    public Task<string> LoadPolicyAsync() => Task.FromResult(_policy);
-
-    public Task SavePolicyAsync(string policyJson)
+    public Task<IReadOnlyList<ApiKeyDto>> GetApiKeysAsync() => Task.FromResult((IReadOnlyList<ApiKeyDto>)_apiKeys);
+    public Task<ApiKeyDto> CreateApiKeyAsync(ApiKeyDto key)
     {
-        _policy = policyJson;
+        _apiKeys.Add(key);
+        return Task.FromResult(key);
+    }
+    public Task DeleteApiKeyAsync(string id)
+    {
+        _apiKeys.RemoveAll(k => k.Id == id);
         return Task.CompletedTask;
     }
 
-    public Task<string> SuggestPolicyPatchAsync(string policyJson)
+    public Task<IReadOnlyList<RouteDto>> GetRoutesAsync() => Task.FromResult((IReadOnlyList<RouteDto>)_routes);
+    public Task<RouteDto> CreateRouteAsync(RouteDto route)
     {
-        return Task.FromResult(policyJson);
+        _routes.Add(route);
+        return Task.FromResult(route);
     }
+    public Task DeleteRouteAsync(string id)
+    {
+        _routes.RemoveAll(r => r.Id == id);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<RateLimitPlanDto>> GetRateLimitPlansAsync() => Task.FromResult((IReadOnlyList<RateLimitPlanDto>)_plans);
+    public Task<RateLimitPlanDto> CreateRateLimitPlanAsync(RateLimitPlanDto plan)
+    {
+        _plans.Add(plan);
+        return Task.FromResult(plan);
+    }
+    public Task DeleteRateLimitPlanAsync(string plan)
+    {
+        _plans.RemoveAll(p => p.Plan == plan);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<WafRuleDto>> GetWafRulesAsync() => Task.FromResult((IReadOnlyList<WafRuleDto>)_waf);
+    public Task ToggleWafRuleAsync(string rule, bool enabled)
+    {
+        var item = _waf.FirstOrDefault(w => w.Rule == rule);
+        if (item != null)
+        {
+            _waf.Remove(item);
+            _waf.Add(item with { Enabled = enabled });
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<AuditEntryDto>> GetAuditEntriesAsync() => Task.FromResult((IReadOnlyList<AuditEntryDto>)_audit);
 }

--- a/src/ui/dashboard/Services/Real/RealControlPlaneService.cs
+++ b/src/ui/dashboard/Services/Real/RealControlPlaneService.cs
@@ -1,3 +1,6 @@
+using System.Net.Http.Json;
+using Dashboard.Models;
+
 namespace Dashboard.Services.Real;
 
 public class RealControlPlaneService : IControlPlaneService
@@ -5,15 +8,69 @@ public class RealControlPlaneService : IControlPlaneService
     private readonly HttpClient _http;
     public RealControlPlaneService(HttpClient http) => _http = http;
 
-    public Task ApplyFixAsync(string incidentId)
-        => throw new NotImplementedException("Coming soon");
+    public async Task ApplyFixAsync(string incidentId)
+    {
+        var res = await _http.PostAsync($"cp/incidents/{incidentId}/apply", null);
+        res.EnsureSuccessStatusCode();
+    }
 
-    public Task<string> LoadPolicyAsync()
-        => throw new NotImplementedException("Coming soon");
+    public async Task<IReadOnlyList<ApiKeyDto>> GetApiKeysAsync()
+        => await _http.GetFromJsonAsync<List<ApiKeyDto>>("cp/apikeys") ?? new();
 
-    public Task SavePolicyAsync(string policyJson)
-        => throw new NotImplementedException("Coming soon");
+    public async Task<ApiKeyDto> CreateApiKeyAsync(ApiKeyDto key)
+    {
+        var res = await _http.PostAsJsonAsync("cp/apikeys", key);
+        res.EnsureSuccessStatusCode();
+        return await res.Content.ReadFromJsonAsync<ApiKeyDto>() ?? key;
+    }
 
-    public Task<string> SuggestPolicyPatchAsync(string policyJson)
-        => throw new NotImplementedException("Coming soon");
+    public async Task DeleteApiKeyAsync(string id)
+    {
+        var res = await _http.DeleteAsync($"cp/apikeys/{id}");
+        res.EnsureSuccessStatusCode();
+    }
+
+    public async Task<IReadOnlyList<RouteDto>> GetRoutesAsync()
+        => await _http.GetFromJsonAsync<List<RouteDto>>("cp/routes") ?? new();
+
+    public async Task<RouteDto> CreateRouteAsync(RouteDto route)
+    {
+        var res = await _http.PostAsJsonAsync("cp/routes", route);
+        res.EnsureSuccessStatusCode();
+        return await res.Content.ReadFromJsonAsync<RouteDto>() ?? route;
+    }
+
+    public async Task DeleteRouteAsync(string id)
+    {
+        var res = await _http.DeleteAsync($"cp/routes/{id}");
+        res.EnsureSuccessStatusCode();
+    }
+
+    public async Task<IReadOnlyList<RateLimitPlanDto>> GetRateLimitPlansAsync()
+        => await _http.GetFromJsonAsync<List<RateLimitPlanDto>>("cp/ratelimits") ?? new();
+
+    public async Task<RateLimitPlanDto> CreateRateLimitPlanAsync(RateLimitPlanDto plan)
+    {
+        var res = await _http.PostAsJsonAsync("cp/ratelimits", plan);
+        res.EnsureSuccessStatusCode();
+        return await res.Content.ReadFromJsonAsync<RateLimitPlanDto>() ?? plan;
+    }
+
+    public async Task DeleteRateLimitPlanAsync(string plan)
+    {
+        var res = await _http.DeleteAsync($"cp/ratelimits/{plan}");
+        res.EnsureSuccessStatusCode();
+    }
+
+    public async Task<IReadOnlyList<WafRuleDto>> GetWafRulesAsync()
+        => await _http.GetFromJsonAsync<List<WafRuleDto>>("cp/waf") ?? new();
+
+    public async Task ToggleWafRuleAsync(string rule, bool enabled)
+    {
+        var res = await _http.PostAsJsonAsync($"cp/waf/{rule}", new { enabled });
+        res.EnsureSuccessStatusCode();
+    }
+
+    public async Task<IReadOnlyList<AuditEntryDto>> GetAuditEntriesAsync()
+        => await _http.GetFromJsonAsync<List<AuditEntryDto>>("cp/audit") ?? new();
 }


### PR DESCRIPTION
## Summary
- replace legacy Policies editor with colorful tabbed management UI
- expand control plane service with typed DTOs for API keys, routes, rate limits, WAF rules and audit log
- add mock and real implementations for new service contracts

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ac48ec648326a008602a62b34cb1