### PR TITLE
Show timestamps on metrics charts

### DIFF
--- a/src/ui/dashboard/Hubs/MetricsHub.cs
+++ b/src/ui/dashboard/Hubs/MetricsHub.cs
@@ -13,6 +13,7 @@ public class MetricsHub : Hub
         while (!token.IsCancellationRequested)
         {
             var metric = new MetricDto(
+                DateTime.UtcNow,
                 rnd.NextDouble() * 100, // Requests per second
                 rnd.NextDouble() * 8,   // UA entropy
                 rnd.Next(0, 20),        // Schema errors

--- a/src/ui/dashboard/Models/MetricDto.cs
+++ b/src/ui/dashboard/Models/MetricDto.cs
@@ -1,3 +1,3 @@
 namespace Dashboard.Models;
 
-public record MetricDto(double Rps, double UaEntropy, int SchemaErrors, int WafBlocks);
+public record MetricDto(DateTime Timestamp, double Rps, double UaEntropy, int SchemaErrors, int WafBlocks);

--- a/src/ui/dashboard/Pages/Metrics.razor
+++ b/src/ui/dashboard/Pages/Metrics.razor
@@ -41,7 +41,7 @@
                                 }
                 else
                 {
-                    <MudText Typo="Typo.body2">In attesa dati… (@rpsSamples.Count)</MudText>
+                    <MudText Typo="Typo.body2">In attesa dati (@rpsSamples.Count)</MudText>
                 }
             </div>
         </MudPaper>
@@ -63,7 +63,7 @@
                                 }
                 else
                 {
-                    <MudText Typo="Typo.body2">In attesa dati… (@uaEntropySamples.Count)</MudText>
+                    <MudText Typo="Typo.body2">In attesa dati (@uaEntropySamples.Count)</MudText>
                 }
             </div>
         </MudPaper>
@@ -85,7 +85,7 @@
                                 }
                 else
                 {
-                    <MudText Typo="Typo.body2">In attesa dati… (@schemaErrorSamples.Count)</MudText>
+                    <MudText Typo="Typo.body2">In attesa dati (@schemaErrorSamples.Count)</MudText>
                 }
             </div>
         </MudPaper>
@@ -107,7 +107,7 @@
                                 }
                 else
                 {
-                    <MudText Typo="Typo.body2">In attesa dati… (@wafBlockSamples.Count)</MudText>
+                    <MudText Typo="Typo.body2">In attesa dati (@wafBlockSamples.Count)</MudText>
                 }
             </div>
         </MudPaper>
@@ -125,8 +125,6 @@
     private readonly List<double> uaEntropySamples = new();
     private readonly List<double> schemaErrorSamples = new();
     private readonly List<double> wafBlockSamples = new();
-
-    private int sampleIndex;
     private const int MaxSamples = 20;
     private CancellationTokenSource? cts;
     private IJSObjectReference? module;
@@ -186,8 +184,7 @@
         if (_disposed || cts?.IsCancellationRequested == true)
             return Task.CompletedTask;
 
-        labels.Add(sampleIndex.ToString());
-        sampleIndex++;
+        labels.Add(m.Timestamp.ToString("HH:mm:ss"));
 
         rpsSamples.Add(Sanitize(m.Rps, rpsSamples));
         uaEntropySamples.Add(Sanitize(m.UaEntropy, uaEntropySamples));


### PR DESCRIPTION
## Summary
- include timestamp in `MetricDto`
- send timestamp from metrics hub and display as x-axis labels

## Testing
- `dotnet test` *(fails: command not found; package installation blocked by 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b946da8083269a50e8dedd6a7b9b