### PR TITLE
Add Gateway E2E tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,53 @@ jobs:
             **/TestResults/*.trx
             **/TestResults/*/coverage.cobertura.xml
             ${{ steps.coverage.outputs.file }}
+
+  e2e-tests:
+    if: github.event_name == 'pull_request'
+    name: Gateway E2E Tests (.NET 9)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+          cache: true
+          cache-dependency-path: |
+            **/*.sln
+            **/*.csproj
+            **/global.json
+            **/nuget.config
+
+      - name: Restore
+        run: |
+          if [ "${USE_LOCKED_MODE}" = "true" ]; then
+            dotnet restore --locked-mode
+          else
+            dotnet restore
+          fi
+
+      - name: Build Gateway & E2E Tests
+        run: >
+          dotnet build
+          src/gateway/Gateway.csproj
+          tests/Gateway.E2ETests/Gateway.E2ETests.csproj
+          --configuration Release --no-restore
+
+      - name: Test (E2E)
+        run: >
+          dotnet test tests/Gateway.E2ETests --configuration Release
+          --no-build --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          if-no-files-found: warn
+          path: |
+            **/TestResults/*.trx


### PR DESCRIPTION
## Summary
- add e2e-tests job to run Gateway E2E tests on pull requests
- build Gateway and test projects and upload test results as artifacts

## Testing
- ⚠️ `wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh` (Proxy tunneling failed)
- ⚠️ `dotnet test tests/Gateway.E2ETests` (command not found: dotnet)

------
https://chatgpt.com/codex/tasks/task_e_68b2cbb93c8c832691eef32ced4463cf